### PR TITLE
Add resource group to values.yaml

### DIFF
--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -4,6 +4,7 @@ java:
   aadIdentityName: reform-scan
   keyVaults:
     reform-scan:
+      resourceGroup: reform-scan
       secrets:
         - app-insights-instrumentation-key
   environment:


### PR DESCRIPTION
### Change description ###

#10 added key vault section in `values.yaml`. From what I see I think assignment of `resourceGroup` is missing. This PR attempts to fix staging pods. Actual app pods will be bumped once correct versions are stable and additional config is present. Hence the `SNAPSHOT` in #10 😉 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
