### PR TITLE
Add CI workflow - publish swagger specs

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -1,0 +1,38 @@
+name: Publish Swagger Specs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run integration tests
+        run: ./gradlew integration --tests uk.gov.hmcts.reform.blobrouter.config.SwaggerPublisher
+      - name: Commit to repository
+        run: |
+          mkdir swagger-staging
+          cd swagger-staging
+          git init
+          git config user.email "jenkins-reform-bulkscan@users.noreply.github.com"
+          git config user.name "Reform BulkScan"
+          git remote add upstream https://${{ secrets.GH_TOKEN }}@github.com/hmcts/reform-api-docs.git
+          git pull upstream master
+          repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
+          echo "$(cat /tmp/swagger-specs.json)" > "docs/specs/$repo.json"
+          git add "docs/specs/$repo.json"
+          # Only commit and push if we have changes
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update spec for $repo#${GITHUB_SHA:7}"; git push --set-upstream upstream master)


### PR DESCRIPTION
### JIRA link (if applicable) ###

Slightly related to [New API in the existing API Management Service](https://tools.hmcts.net/jira/browse/BPS-870)

### Change description ###

In order to create such management/module it is required to have swagger specs published. We should publish anyway so trying out this new github action

Initiated by this PR during debug: https://github.com/hmcts/reform-api-docs/commit/77ea73f5d6ac39314d0cef91ae048ab348669d3e

Changed to master at the end as it is what we want

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
