### PR TITLE
Fix api management parameters

### DIFF
--- a/infrastructure/api-mgmt.tf
+++ b/infrastructure/api-mgmt.tf
@@ -31,9 +31,9 @@ module "api_mgmt" {
   revision      = "1"
   product_id    = "${module.api_mgmt_product.product_id}"
   display_name  = "Get SAS token for storage account access"
-  path          = "/token/*"
+  path          = "token"
   protocols = [
-    "HTTPS"
+    "https"
   ]
   service_url = "http://${var.product}-${var.component}-${var.env}.service.core-compute-${var.env}.internal"
   swagger_url = "https://hmcts.github.io/reform-api-docs/specs/blob-router-service.json"


### PR DESCRIPTION
### Change description ###

- No `/` at the beginning not ending. I'm assuming `*` either as similar question was raised by platform
- HTTPS must be lowercase

These errors are due to copy/paste from processor in order to maintain the exact setup as closely as possible

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
