### PR TITLE
Set protocol for SAS token generation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.blobrouter.services;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.sas.SasProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -53,6 +54,7 @@ public class SasTokenGeneratorService {
         return new BlobServiceSasSignatureValues()
             .setContainerName(serviceName)
             .setExpiryTime(OffsetDateTime.now().plusSeconds(config.getSasValidity()))
+            .setProtocol(SasProtocol.HTTPS_HTTP)
             .setPermissions(permissions);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
@@ -57,6 +57,7 @@ class SasTokenGeneratorServiceTest {
         OffsetDateTime expiresAt = OffsetDateTime.parse(queryParams.get("se")[0]); //expiry datetime for the signature
         assertThat(expiresAt).isBetween(now, now.plusSeconds(300));
         assertThat(queryParams.get("sp")).contains("wl");//access permissions(write-w,list-l)
+        assertThat(queryParams.get("spr")).containsExactlyInAnyOrder("https","http");
     }
 
     @Test


### PR DESCRIPTION
## Change description ###

- We need to set protocol for SAS defined by spr parameter in the SAS token string. If we don't set this then SAS token are generated without spr parameter and blob storage service throws 403 forbidden error.

- Tested by generating token for AAT 
<img width="460" alt="image" src="https://user-images.githubusercontent.com/13840402/70523692-81a02d00-1b3b-11ea-8fae-4b2f807890cf.png">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
