### PR TITLE
Updated bootstrap mappings to use env var name used in app yaml

### DIFF
--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -8,4 +8,4 @@ spring:
         app-insights-instrumentation-key: azure.application-insights.instrumentation-key
         storage-account-name: STORAGE_ACCOUNT_NAME
         storage-account-primary-key: STORAGE_ACCOUNT_KEY
-        storage-account-secondary-key: STORAGE_ACCOUNT_SECONDARY_KEYy
+        storage-account-secondary-key: STORAGE_ACCOUNT_SECONDARY_KEY

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -6,6 +6,6 @@ spring:
       paths: /mnt/secrets/reform-scan
       aliases:
         app-insights-instrumentation-key: azure.application-insights.instrumentation-key
-        storage-account-name: storage.account-name
-        storage-account-primary-key: storage.account-key
-        storage-account-secondary-key: storage.account-secondary-key
+        storage-account-name: STORAGE_ACCOUNT_NAME
+        storage-account-primary-key: STORAGE_ACCOUNT_KEY
+        storage-account-secondary-key: STORAGE_ACCOUNT_SECONDARY_KEYy


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-962

### Change description ###

- Bootstrap mapping was incorrect as we have configured env var name as `STORAGE_ACCOUNT_NAME` in `application.yaml` and flex volume would map `storage.account-name` to `STORAGE_ACCOUNT-NAME` with previous configuration.

- Same for other two keys.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
