### PR TITLE
Fixed bootstrap config and removed defaults

### DIFF
--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -14,12 +14,13 @@ java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   aadIdentityName:
-  blobstorage:
-    resourceGroup: reform-scan-aks
-    teamName: "BSP"
-    location: ukwest
-    setup:
-      containers:
-        - bulkscan
-        - bulkscan-rejected
-    enabled: true
+
+blobstorage:
+  resourceGroup: reform-scan-aks
+  teamName: "BSP"
+  location: ukwest
+  setup:
+    containers:
+      - bulkscan
+      - bulkscan-rejected
+  enabled: true

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -5,10 +5,10 @@ java:
       key: storageAccountName
     STORAGE_ACCOUNT_KEY:
       secretRef: storage-secret-{{ .Release.Name }}
-      key: primaryAccessKey
+      key: accessKey
     STORAGE_ACCOUNT_SECONDARY_KEY:
       secretRef: storage-secret-{{ .Release.Name }}
-      key: secondaryAccessKey
+      key: accessKey
   environment:
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -1,6 +1,25 @@
 java:
+  secrets:
+    STORAGE_ACCOUNT_NAME:
+      secretRef: storage-secret-{{ .Release.Name }}
+      key: storageAccountName
+    STORAGE_ACCOUNT_KEY:
+      secretRef: storage-secret-{{ .Release.Name }}
+      key: primaryAccessKey
+    STORAGE_ACCOUNT_SECONDARY_KEY:
+      secretRef: storage-secret-{{ .Release.Name }}
+      key: secondaryAccessKey
   environment:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   aadIdentityName:
+  blobstorage:
+    resourceGroup: reform-scan-aks
+    teamName: "BSP"
+    location: ukwest
+    setup:
+      containers:
+        - bulkscan
+        - bulkscan-rejected
+    enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,9 +14,9 @@ spring:
     name: Blob Router Service
 
 storage:
-  account-name: ${STORAGE_ACCOUNT_NAME:reformscansandbox}
-  account-key: ${STORAGE_ACCOUNT_KEY:dGVzdA==} #Base 64 encoded
-  account-secondary-key: ${STORAGE_ACCOUNT_SECONDARY_KEY:dGVzdA==} #Base 64 encoded
+  account-name: ${STORAGE_ACCOUNT_NAME}
+  account-key: ${STORAGE_ACCOUNT_KEY} #Base 64 encoded
+  account-secondary-key: ${STORAGE_ACCOUNT_SECONDARY_KEY} #Base 64 encoded
 
 service:
   storage-config:

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -6,6 +6,6 @@ spring:
       paths: /mnt/secrets/reform-scan
       aliases:
         app-insights-instrumentation-key: azure.application-insights.instrumentation-key
-        storage-account-name: STORAGE_ACCOUNT_NAME
-        storage-account-primary-key: STORAGE_ACCOUNT_KEY
-        storage-account-secondary-key: STORAGE_ACCOUNT_SECONDARY_KEY
+        storage-account-name: storage.account_name
+        storage-account-primary-key:  storage.account_key
+        storage-account-secondary-key:  storage.account_secondary_key


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-962

### Change description ###

- Removed default values for storage account name and keys and also updated the mappings.

- Currently after merging https://github.com/hmcts/blob-router-service/pull/42  it is still using default values for storage name and key which means bootstrap mappings seems incorrect.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
