### PR TITLE
Add badge with link to swagger specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Blob Router
 
 ![](https://github.com/hmcts/blob-router-service/workflows/CI/badge.svg)
+[![](https://github.com/hmcts/blob-router-service/workflows/Publish%20Swagger%20Specs/badge.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/blob-router-service.json)
 [![codecov](https://codecov.io/gh/hmcts/blob-router-service/branch/master/graph/badge.svg)](https://codecov.io/gh/hmcts/blob-router-service)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c99af8bcd53947deb32e8f0a7c500676)](https://www.codacy.com/manual/HMCTS/blob-router-service)
 


### PR DESCRIPTION
### Change description ###

Swagger specs are mentioned in README. Just adding a badge on top of the README since GitHub Actions have such feature (see CI badge). Also wrapping with extra link to actual specs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
