### PR TITLE
Copy bulkscan storage account secrets to reform key vault

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,41 @@
 provider "azurerm" {
   version = "=1.33.1"
 }
+
+locals {
+  reform-scan-vault-name = "reform-scan-${var.env}"
+  bulk-scan-vault-name   = "bulk-scan-${var.env}"
+}
+
+data "azurerm_key_vault" "bulk_scan_key_vault" {
+  name                = "${local.bulk-scan-vault-name}"
+  resource_group_name = "bulk-scan-${var.env}"
+}
+
+data "azurerm_key_vault_secret" "bulk_scan_storage_account_name" {
+  key_vault_id = "${data.azurerm_key_vault.bulk_scan_key_vault.id}"
+  name         = "storage-account-name"
+}
+
+data "azurerm_key_vault_secret" "bulk_scan_storage_account_primary_key" {
+  key_vault_id = "${data.azurerm_key_vault.bulk_scan_key_vault.id}"
+  name         = "storage-account-primary-key"
+}
+
+# Copy CFT storage account secrets from bulk-scan key vault to reform-scan key vault
+data "azurerm_key_vault" "reform_scan_key_vault" {
+  name                = "${local.reform-scan-vault-name}"
+  resource_group_name = "reform-scan-${var.env}"
+}
+
+resource "azurerm_key_vault_secret" "reform_bulk_scan_storage_account_name" {
+  name         = "reform-bulk-scan-storage-account-name"
+  value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_name.value}"
+  key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
+}
+
+resource "azurerm_key_vault_secret" "reform_bulk_scan_storage_account_primary_key" {
+  name         = "reform-bulk-scan-storage-account-primary-key"
+  value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_primary_key.value}"
+  key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,14 +28,14 @@ data "azurerm_key_vault" "reform_scan_key_vault" {
   resource_group_name = "reform-scan-${var.env}"
 }
 
-resource "azurerm_key_vault_secret" "reform_bulk_scan_storage_account_name" {
-  name         = "reform-bulk-scan-storage-account-name"
+resource "azurerm_key_vault_secret" "bulkscan_storage_account_name" {
+  name         = "bulkscan-storage-account-name"
   value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_name.value}"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
 }
 
-resource "azurerm_key_vault_secret" "reform_bulk_scan_storage_account_primary_key" {
-  name         = "reform-bulk-scan-storage-account-primary-key"
+resource "azurerm_key_vault_secret" "bulkscan_storage_account_primary_key" {
+  name         = "bulkscan-storage-account-primary-key"
   value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_primary_key.value}"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-919

### Change description ###
Related to https://github.com/hmcts/blob-router-service/pull/62
Terraform file changes to copy bulk scan storage account secrets 
from bulk scan key vault to reform key vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
