### PR TITLE
Include http configuration for AppInsights telemetries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,7 @@ dependencies {
 
   // region: feign clients
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.1.RELEASE'
+  implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.4.0'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '10.4.0'
   // end region
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/HttpConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/HttpConfiguration.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.blobrouter.config;
+
+import feign.Client;
+import feign.httpclient.ApacheHttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpConfiguration {
+
+    @Bean
+    public Client getFeignHttpClient() {
+        return new ApacheHttpClient(getHttpClient());
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate(clientHttpRequestFactory());
+    }
+
+    @Bean
+    public HttpComponentsClientHttpRequestFactory clientHttpRequestFactory() {
+        return new HttpComponentsClientHttpRequestFactory(getHttpClient());
+    }
+
+    private CloseableHttpClient getHttpClient() {
+        RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(30000)
+            .setConnectionRequestTimeout(30000)
+            .setSocketTimeout(60000)
+            .build();
+
+        return HttpClientBuilder
+            .create()
+            .useSystemProperties()
+            .setDefaultRequestConfig(config)
+            .build();
+    }
+}


### PR DESCRIPTION
### Change description ###

This is iterated among our services and proven multiple times already. Registering beans for tracking HTTP calls to AppInsights

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
