### PR TITLE
Add blob dispatcher component

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -12,6 +12,7 @@ class BlobDispatcherTest extends TestBase {
 
     private static final String NEW_BLOB_NAME = "new.blob";
     private static final String DESTINATION_CONTAINER = "bulkscan";
+    private static final String BOGUS_CONTAINER = "bogus";
 
     private BlobDispatcher dispatcher;
 
@@ -32,6 +33,13 @@ class BlobDispatcherTest extends TestBase {
     void should_upload_blob_to_dedicated_container() {
         assertThatCode(() -> dispatcher
             .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_catch_BlobStorageException_and_suppress_it() {
+        assertThatCode(() -> dispatcher
+            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), BOGUS_CONTAINER)
         ).doesNotThrowAnyException();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.core.test.TestBase;
-import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.BlobServiceClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
-
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -26,7 +24,7 @@ class BlobDispatcherTest extends TestBase {
 
     @Override
     protected void beforeTest() {
-        BlobServiceAsyncClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
+        BlobServiceClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
         dispatcher = new BlobDispatcher(storageClient);
     }
 
@@ -34,7 +32,6 @@ class BlobDispatcherTest extends TestBase {
     void should_upload_blob_to_dedicated_container() {
         assertThatCode(() -> dispatcher
             .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
-            .block(Duration.ofSeconds(2)) // max waiting time
         ).doesNotThrowAnyException();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -4,17 +4,12 @@ import com.azure.core.test.TestBase;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@ExtendWith(OutputCaptureExtension.class)
 class BlobDispatcherTest extends TestBase {
 
     private static final String NEW_BLOB_NAME = "new.blob";
@@ -36,14 +31,10 @@ class BlobDispatcherTest extends TestBase {
     }
 
     @Test
-    void should_upload_blob_to_dedicated_container(CapturedOutput output) {
+    void should_upload_blob_to_dedicated_container() {
         assertThatCode(() -> dispatcher
             .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
             .block(Duration.ofSeconds(2)) // max waiting time
         ).doesNotThrowAnyException();
-
-        assertThat(output).contains(
-            "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"
-        );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -9,10 +9,7 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.time.Duration;
-import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -39,13 +36,11 @@ class BlobDispatcherTest extends TestBase {
     }
 
     @Test
-    void should_upload_blob_to_dedicated_container(CapturedOutput output) throws IOException {
-        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(NEW_BLOB_NAME.getBytes()))) {
-            assertThatCode(() -> dispatcher
-                .dispatch(NEW_BLOB_NAME, inputStream, DESTINATION_CONTAINER)
-                .block(Duration.ofSeconds(2)) // max waiting time
-            ).doesNotThrowAnyException();
-        }
+    void should_upload_blob_to_dedicated_container(CapturedOutput output) {
+        assertThatCode(() -> dispatcher
+            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
+            .block(Duration.ofSeconds(2)) // max waiting time
+        ).doesNotThrowAnyException();
 
         assertThat(output).contains(
             "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.core.test.TestBase;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SuppressWarnings("java:S2925") // ignore Thread.sleep() call in the tests
+class BlobDispatcherTest extends TestBase {
+
+    private static final String NEW_BLOB_NAME = "new.blob";
+    private static final String DESTINATION_CONTAINER = "bulkscan";
+
+    private BlobDispatcher dispatcher;
+
+    @BeforeAll
+    static void setUpTestMode() {
+        StorageClientsHelper.setAzureTestMode();
+
+        setupClass();
+    }
+
+    @Override
+    protected void beforeTest() {
+        BlobServiceAsyncClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
+        dispatcher = new BlobDispatcher(storageClient);
+    }
+
+    @Test
+    void should_upload_blob_to_dedicated_container(CapturedOutput output) throws IOException, InterruptedException {
+        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(NEW_BLOB_NAME.getBytes()))) {
+            dispatcher.dispatch(NEW_BLOB_NAME, inputStream, DESTINATION_CONTAINER);
+        }
+
+        Thread.sleep(1000); // need to wait for subscriber to be notified
+
+        assertThat(output).contains(
+            "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"
+        );
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.blobrouter.util;
 
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.http.MockHttpResponse;
 import org.junit.jupiter.api.Assertions;
 import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static uk.gov.hmcts.reform.blobrouter.util.ResourceFilesHelper.getFileContents;
 
@@ -14,6 +18,7 @@ class StorageStubHttpClient implements HttpClient {
     private static final String LIST_CONTAINERS = "?comp=list";
     private static final String LIST_ONE_BLOB = "/bulkscan?include=&restype=container&comp=list";
     private static final String LIST_ZERO_BLOBS = "/empty?include=&restype=container&comp=list";
+    private static final String UPLOAD_NEW_BLOB = "/bulkscan/new.blob?null";
 
     @Override
     public Mono<HttpResponse> send(HttpRequest request) {
@@ -32,6 +37,17 @@ class StorageStubHttpClient implements HttpClient {
             case LIST_ZERO_BLOBS:
                 return Mono.just(
                     new MockHttpResponse(request, 200, getFileContents("storage/list-empty-blobs.json"))
+                );
+            case UPLOAD_NEW_BLOB:
+                Map<String, String> headers = new HashMap<>();
+                headers.put("ETag", "0x8D761B5AF5CA061");
+                headers.put("Last-Modified", "Tue, 05 Nov 2019 06:02:05 GMT");
+                headers.put("x-ms-request-server-encrypted", "false");
+                headers.put("x-ms-encryption-key-sha256", "sha256");
+                request.getHeaders().put("x-ms-encryption-key-sha256", "sha256");
+
+                return Mono.just(
+                    new MockHttpResponse(request, 201, new HttpHeaders(headers))
                 );
             default:
                 Assertions.fail("Request '" + request.getUrl() + "' is not set up");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
@@ -10,6 +10,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.hmcts.reform.blobrouter.util.ResourceFilesHelper.getFileContents;
 
@@ -18,12 +19,12 @@ class StorageStubHttpClient implements HttpClient {
     private static final String LIST_CONTAINERS = "?comp=list";
     private static final String LIST_ONE_BLOB = "/bulkscan?include=&restype=container&comp=list";
     private static final String LIST_ZERO_BLOBS = "/empty?include=&restype=container&comp=list";
-    private static final String UPLOAD_NEW_BLOB = "/bulkscan/new.blob?null";
+    private static final String UPLOAD_NEW_BLOB = "/bulkscan/new.blob?";
 
     @Override
     public Mono<HttpResponse> send(HttpRequest request) {
         String path = request.getUrl().getPath();
-        String query = request.getUrl().getQuery();
+        String query = Objects.toString(request.getUrl().getQuery(), "");
 
         switch (path + "?" + query) {
             case LIST_CONTAINERS:

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
@@ -26,6 +26,12 @@ class StorageStubHttpClient implements HttpClient {
         String path = request.getUrl().getPath();
         String query = Objects.toString(request.getUrl().getQuery(), "");
 
+        if (path.contains("bogus")) {
+            return Mono.just(
+                new MockHttpResponse(request, 400)
+            );
+        }
+
         switch (path + "?" + query) {
             case LIST_CONTAINERS:
                 return Mono.just(

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -7,9 +7,7 @@ import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.zip.ZipInputStream;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -23,21 +21,15 @@ public class BlobDispatcher {
         this.storageClient = storageClient;
     }
 
-    public Mono<BlockBlobItem> dispatch(
-        String blobName,
-        ZipInputStream inputStream,
-        String destinationContainer
-    ) throws IOException {
-        byte[] zip = inputStream.readAllBytes();
-
+    public Mono<BlockBlobItem> dispatch(String blobName, byte[] blobContents, String destinationContainer) {
         logger.info("Uploading {} to {} container", blobName, destinationContainer);
 
         return getContainerClient(destinationContainer)
             .getBlobAsyncClient(blobName)
             .getBlockBlobAsyncClient()
             .upload(
-                Flux.just(ByteBuffer.wrap(zip)),
-                zip.length,
+                Flux.just(ByteBuffer.wrap(blobContents)),
+                blobContents.length,
                 false // overwrite flag
             )
             .doOnError(error -> logger.error(

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.models.BlockBlobItem;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -21,12 +23,16 @@ public class BlobDispatcher {
         this.storageClient = storageClient;
     }
 
-    public void dispatch(String blobName, ZipInputStream inputStream, String destinationContainer) throws IOException {
+    public Mono<BlockBlobItem> dispatch(
+        String blobName,
+        ZipInputStream inputStream,
+        String destinationContainer
+    ) throws IOException {
         byte[] zip = inputStream.readAllBytes();
 
         logger.info("Uploading {} to {} container", blobName, destinationContainer);
 
-        getContainerClient(destinationContainer)
+        return getContainerClient(destinationContainer)
             .getBlobAsyncClient(blobName)
             .getBlockBlobAsyncClient()
             .upload(
@@ -42,8 +48,7 @@ public class BlobDispatcher {
             ))
             .doOnSuccess(uploadedBlob ->
                 logger.info("Finished uploading {} to {} container", blobName, destinationContainer)
-            )
-            .subscribe();
+            );
     }
 
     // will use different storageClient depending on container

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobContainerAsyncClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.zip.ZipInputStream;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class BlobDispatcher {
+
+    private static final Logger logger = getLogger(BlobDispatcher.class);
+
+    private final BlobServiceAsyncClient storageClient;
+
+    public BlobDispatcher(BlobServiceAsyncClient storageClient) {
+        this.storageClient = storageClient;
+    }
+
+    public void dispatch(String blobName, ZipInputStream inputStream, String destinationContainer) throws IOException {
+        byte[] zip = inputStream.readAllBytes();
+
+        logger.info("Uploading {} to {} container", blobName, destinationContainer);
+
+        getContainerClient(destinationContainer)
+            .getBlobAsyncClient(blobName)
+            .getBlockBlobAsyncClient()
+            .upload(
+                Flux.just(ByteBuffer.wrap(zip)),
+                zip.length,
+                false // overwrite flag
+            )
+            .doOnError(error -> logger.error(
+                "Error occurred while uploading {} to {} container",
+                blobName,
+                destinationContainer,
+                error
+            ))
+            .doOnSuccess(uploadedBlob ->
+                logger.info("Finished uploading {} to {} container", blobName, destinationContainer)
+            )
+            .subscribe();
+    }
+
+    // will use different storageClient depending on container
+    private BlobContainerAsyncClient getContainerClient(String destinationContainer) {
+        return storageClient.getBlobContainerAsyncClient(destinationContainer);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -27,8 +27,7 @@ public class BlobDispatcher {
                 .getBlockBlobClient()
                 .upload(
                     new ByteArrayInputStream(blobContents),
-                    blobContents.length,
-                    false // overwrite flag
+                    blobContents.length
                 );
 
             logger.info("Finished uploading {} to {} container", blobName, destinationContainer);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create blob processing component](https://tools.hmcts.net/jira/browse/BPS-919)

### Change description ###

Adding component for uploading zip files to storage containers. Including only one dependency which is not yet beaned up. Current plan we have: 2 destinations meaning 2 autowired storage clients

~P.S. Need advice/help on integration test~

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
