### PR TITLE
Add subscriber for processing blobs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -4,17 +4,12 @@ import com.azure.core.test.TestBase;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@ExtendWith(OutputCaptureExtension.class)
 class BlobDispatcherTest extends TestBase {
 
     private static final String NEW_BLOB_NAME = "new.blob";
@@ -36,14 +31,10 @@ class BlobDispatcherTest extends TestBase {
     }
 
     @Test
-    void should_upload_blob_to_dedicated_container(CapturedOutput output) {
+    void should_upload_blob_to_dedicated_container() {
         assertThatCode(() -> dispatcher
             .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
             .block(Duration.ofSeconds(2)) // max waiting time
         ).doesNotThrowAnyException();
-
-        assertThat(output).contains(
-            "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"
-        );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -9,10 +9,7 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.time.Duration;
-import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -39,13 +36,11 @@ class BlobDispatcherTest extends TestBase {
     }
 
     @Test
-    void should_upload_blob_to_dedicated_container(CapturedOutput output) throws IOException {
-        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(NEW_BLOB_NAME.getBytes()))) {
-            assertThatCode(() -> dispatcher
-                .dispatch(NEW_BLOB_NAME, inputStream, DESTINATION_CONTAINER)
-                .block(Duration.ofSeconds(2)) // max waiting time
-            ).doesNotThrowAnyException();
-        }
+    void should_upload_blob_to_dedicated_container(CapturedOutput output) {
+        assertThatCode(() -> dispatcher
+            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
+            .block(Duration.ofSeconds(2)) // max waiting time
+        ).doesNotThrowAnyException();
 
         assertThat(output).contains(
             "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.core.test.TestBase;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SuppressWarnings("java:S2925") // ignore Thread.sleep() call in the tests
+class BlobDispatcherTest extends TestBase {
+
+    private static final String NEW_BLOB_NAME = "new.blob";
+    private static final String DESTINATION_CONTAINER = "bulkscan";
+
+    private BlobDispatcher dispatcher;
+
+    @BeforeAll
+    static void setUpTestMode() {
+        StorageClientsHelper.setAzureTestMode();
+
+        setupClass();
+    }
+
+    @Override
+    protected void beforeTest() {
+        BlobServiceAsyncClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
+        dispatcher = new BlobDispatcher(storageClient);
+    }
+
+    @Test
+    void should_upload_blob_to_dedicated_container(CapturedOutput output) throws IOException, InterruptedException {
+        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(NEW_BLOB_NAME.getBytes()))) {
+            dispatcher.dispatch(NEW_BLOB_NAME, inputStream, DESTINATION_CONTAINER);
+        }
+
+        Thread.sleep(1000); // need to wait for subscriber to be notified
+
+        assertThat(output).contains(
+            "Finished uploading " + NEW_BLOB_NAME + " to " + DESTINATION_CONTAINER + " container"
+        );
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriberTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriberTest.java
@@ -7,18 +7,13 @@ import com.azure.storage.blob.specialized.BlobLeaseAsyncClient;
 import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import reactor.util.function.Tuples;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
 import java.nio.ByteBuffer;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@ExtendWith(OutputCaptureExtension.class)
 public class BlobProcessorSubscriberTest extends TestBase {
 
     private static final String BLOB_NAME = "new.blob";
@@ -54,11 +49,7 @@ public class BlobProcessorSubscriberTest extends TestBase {
     }
 
     @Test
-    void should_log_error_and_not_throw_exception_when_process_receives_something_unexpected(CapturedOutput output) {
+    void should_log_error_and_not_throw_exception_when_process_receives_something_unexpected() {
         assertThatCode(() -> subscriber.onError(new RuntimeException("oh no"))).doesNotThrowAnyException();
-
-        assertThat(output).contains(
-            "Error occurred while processing " + BLOB_NAME + " blob from " + CONTAINER + " container"
-        );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriberTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriberTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.core.test.TestBase;
+import com.azure.storage.blob.BlobAsyncClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.specialized.BlobLeaseAsyncClient;
+import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import reactor.util.function.Tuples;
+import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class BlobProcessorSubscriberTest extends TestBase {
+
+    private static final String BLOB_NAME = "new.blob";
+    private static final String CONTAINER = "bulkscan";
+
+    private BlobProcessorSubscriber subscriber;
+
+    @BeforeAll
+    static void setUpTestMode() {
+        StorageClientsHelper.setAzureTestMode();
+
+        setupClass();
+    }
+
+    @Override
+    protected void beforeTest() {
+        BlobServiceAsyncClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
+        BlobAsyncClient blobClient = storageClient
+            .getBlobContainerAsyncClient(CONTAINER)
+            .getBlobAsyncClient(BLOB_NAME);
+        BlobLeaseAsyncClient blobLeaseClient = new BlobLeaseClientBuilder()
+            .blobAsyncClient(blobClient)
+            .buildAsyncClient();
+        BlobDispatcher dispatcher = new BlobDispatcher(storageClient);
+
+        subscriber = new BlobProcessorSubscriber(blobClient, blobLeaseClient, dispatcher);
+    }
+
+    @Test
+    void should_process_single_blob() {
+        assertThatCode(() -> subscriber.onNext(Tuples.of(ByteBuffer.wrap(BLOB_NAME.getBytes()), "lease ID")))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_log_error_and_not_throw_exception_when_process_receives_something_unexpected(CapturedOutput output) {
+        assertThatCode(() -> subscriber.onError(new RuntimeException("oh no"))).doesNotThrowAnyException();
+
+        assertThat(output).contains(
+            "Error occurred while processing " + BLOB_NAME + " blob from " + CONTAINER + " container"
+        );
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.blobrouter.tasks.processors;
+
+import com.azure.core.test.TestBase;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.models.BlobItem;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
+import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
+
+class BlobProcessorTest extends TestBase {
+
+    private static final String NEW_BLOB_NAME = "new.blob";
+    private static final String CONTAINER = "bulkscan";
+
+    private BlobProcessor processor;
+
+    @BeforeAll
+    static void setUpTestMode() {
+        StorageClientsHelper.setAzureTestMode();
+
+        setupClass();
+    }
+
+    @Override
+    protected void beforeTest() {
+        BlobServiceAsyncClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
+        BlobDispatcher dispatcher = new BlobDispatcher(storageClient);
+
+        processor = new BlobProcessor(storageClient, dispatcher);
+    }
+
+    @Test
+    void should() {
+        BlobItem blob = new BlobItem();
+        blob.setName(NEW_BLOB_NAME);
+
+        processor.process(blob, CONTAINER);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.blobrouter.util;
 
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.http.MockHttpResponse;
 import org.junit.jupiter.api.Assertions;
 import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static uk.gov.hmcts.reform.blobrouter.util.ResourceFilesHelper.getFileContents;
 
@@ -14,6 +18,7 @@ class StorageStubHttpClient implements HttpClient {
     private static final String LIST_CONTAINERS = "?comp=list";
     private static final String LIST_ONE_BLOB = "/bulkscan?include=&restype=container&comp=list";
     private static final String LIST_ZERO_BLOBS = "/empty?include=&restype=container&comp=list";
+    private static final String UPLOAD_NEW_BLOB = "/bulkscan/new.blob?null";
 
     @Override
     public Mono<HttpResponse> send(HttpRequest request) {
@@ -32,6 +37,17 @@ class StorageStubHttpClient implements HttpClient {
             case LIST_ZERO_BLOBS:
                 return Mono.just(
                     new MockHttpResponse(request, 200, getFileContents("storage/list-empty-blobs.json"))
+                );
+            case UPLOAD_NEW_BLOB:
+                Map<String, String> headers = new HashMap<>();
+                headers.put("ETag", "0x8D761B5AF5CA061");
+                headers.put("Last-Modified", "Tue, 05 Nov 2019 06:02:05 GMT");
+                headers.put("x-ms-request-server-encrypted", "false");
+                headers.put("x-ms-encryption-key-sha256", "sha256");
+                request.getHeaders().put("x-ms-encryption-key-sha256", "sha256");
+
+                return Mono.just(
+                    new MockHttpResponse(request, 201, new HttpHeaders(headers))
                 );
             default:
                 Assertions.fail("Request '" + request.getUrl() + "' is not set up");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/StorageStubHttpClient.java
@@ -15,6 +15,7 @@ import static uk.gov.hmcts.reform.blobrouter.util.ResourceFilesHelper.getFileCon
 
 class StorageStubHttpClient implements HttpClient {
 
+    private static final String LEASE_BLOB = "/bulkscan/new.blob?comp=lease";
     private static final String LIST_CONTAINERS = "?comp=list";
     private static final String LIST_ONE_BLOB = "/bulkscan?include=&restype=container&comp=list";
     private static final String LIST_ZERO_BLOBS = "/empty?include=&restype=container&comp=list";
@@ -24,8 +25,20 @@ class StorageStubHttpClient implements HttpClient {
     public Mono<HttpResponse> send(HttpRequest request) {
         String path = request.getUrl().getPath();
         String query = request.getUrl().getQuery();
+        Map<String, String> headers = new HashMap<>();
 
         switch (path + "?" + query) {
+            case LEASE_BLOB:
+                headers.put("ETag", "0x8D761B5AF5CA061");
+                headers.put("Last-Modified", "Tue, 05 Nov 2019 06:02:05 GMT");
+                headers.put("x-ms-lease-id", request.getHeaders().getValue("x-ms-proposed-lease-id"));
+                headers.put("x-ms-client-request-id", request.getHeaders().getValue("x-ms-client-request-id"));
+                headers.put("x-ms-request-id", "request id");
+                headers.put("x-ms-version", request.getHeaders().getValue("x-ms-version"));
+
+                return Mono.just(
+                    new MockHttpResponse(request, 201, new HttpHeaders(headers))
+                );
             case LIST_CONTAINERS:
                 return Mono.just(
                     new MockHttpResponse(request, 200, getFileContents("storage/list-containers.json"))
@@ -39,7 +52,6 @@ class StorageStubHttpClient implements HttpClient {
                     new MockHttpResponse(request, 200, getFileContents("storage/list-empty-blobs.json"))
                 );
             case UPLOAD_NEW_BLOB:
-                Map<String, String> headers = new HashMap<>();
                 headers.put("ETag", "0x8D761B5AF5CA061");
                 headers.put("Last-Modified", "Tue, 05 Nov 2019 06:02:05 GMT");
                 headers.put("x-ms-request-server-encrypted", "false");

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -7,9 +7,7 @@ import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.zip.ZipInputStream;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -23,21 +21,15 @@ public class BlobDispatcher {
         this.storageClient = storageClient;
     }
 
-    public Mono<BlockBlobItem> dispatch(
-        String blobName,
-        ZipInputStream inputStream,
-        String destinationContainer
-    ) throws IOException {
-        byte[] zip = inputStream.readAllBytes();
-
+    public Mono<BlockBlobItem> dispatch(String blobName, byte[] blobContents, String destinationContainer) {
         logger.info("Uploading {} to {} container", blobName, destinationContainer);
 
         return getContainerClient(destinationContainer)
             .getBlobAsyncClient(blobName)
             .getBlockBlobAsyncClient()
             .upload(
-                Flux.just(ByteBuffer.wrap(zip)),
-                zip.length,
+                Flux.just(ByteBuffer.wrap(blobContents)),
+                blobContents.length,
                 false // overwrite flag
             )
             .doOnError(error -> logger.error(

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.models.BlockBlobItem;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -21,12 +23,16 @@ public class BlobDispatcher {
         this.storageClient = storageClient;
     }
 
-    public void dispatch(String blobName, ZipInputStream inputStream, String destinationContainer) throws IOException {
+    public Mono<BlockBlobItem> dispatch(
+        String blobName,
+        ZipInputStream inputStream,
+        String destinationContainer
+    ) throws IOException {
         byte[] zip = inputStream.readAllBytes();
 
         logger.info("Uploading {} to {} container", blobName, destinationContainer);
 
-        getContainerClient(destinationContainer)
+        return getContainerClient(destinationContainer)
             .getBlobAsyncClient(blobName)
             .getBlockBlobAsyncClient()
             .upload(
@@ -42,8 +48,7 @@ public class BlobDispatcher {
             ))
             .doOnSuccess(uploadedBlob ->
                 logger.info("Finished uploading {} to {} container", blobName, destinationContainer)
-            )
-            .subscribe();
+            );
     }
 
     // will use different storageClient depending on container

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobContainerAsyncClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.zip.ZipInputStream;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class BlobDispatcher {
+
+    private static final Logger logger = getLogger(BlobDispatcher.class);
+
+    private final BlobServiceAsyncClient storageClient;
+
+    public BlobDispatcher(BlobServiceAsyncClient storageClient) {
+        this.storageClient = storageClient;
+    }
+
+    public void dispatch(String blobName, ZipInputStream inputStream, String destinationContainer) throws IOException {
+        byte[] zip = inputStream.readAllBytes();
+
+        logger.info("Uploading {} to {} container", blobName, destinationContainer);
+
+        getContainerClient(destinationContainer)
+            .getBlobAsyncClient(blobName)
+            .getBlockBlobAsyncClient()
+            .upload(
+                Flux.just(ByteBuffer.wrap(zip)),
+                zip.length,
+                false // overwrite flag
+            )
+            .doOnError(error -> logger.error(
+                "Error occurred while uploading {} to {} container",
+                blobName,
+                destinationContainer,
+                error
+            ))
+            .doOnSuccess(uploadedBlob ->
+                logger.info("Finished uploading {} to {} container", blobName, destinationContainer)
+            )
+            .subscribe();
+    }
+
+    // will use different storageClient depending on container
+    private BlobContainerAsyncClient getContainerClient(String destinationContainer) {
+        return storageClient.getBlobContainerAsyncClient(destinationContainer);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriber.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobProcessorSubscriber.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobAsyncClient;
+import com.azure.storage.blob.specialized.BlobLeaseAsyncClient;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.zip.ZipInputStream;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class BlobProcessorSubscriber implements Subscriber<Tuple2<ByteBuffer, String>> {
+
+    private static final Logger logger = getLogger(BlobProcessorSubscriber.class);
+
+    private final BlobAsyncClient blobClient;
+    private final BlobLeaseAsyncClient blobLeaseClient;
+    private final BlobDispatcher dispatcher;
+
+    public BlobProcessorSubscriber(
+        BlobAsyncClient blobClient,
+        BlobLeaseAsyncClient blobLeaseClient,
+        BlobDispatcher dispatcher
+    ) {
+        this.blobClient = blobClient;
+        this.blobLeaseClient = blobLeaseClient;
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+
+    }
+
+    // tuple of downloaded blob and lease id
+    @Override
+    public void onNext(Tuple2<ByteBuffer, String> item) {
+        String blobName = blobClient.getBlobName();
+        String containerName = blobClient.getContainerName();
+
+        logger.info("Start processing {} blob from {} container", blobName, containerName);
+
+        try (ZipInputStream inputStream = new ZipInputStream(new ByteArrayInputStream(item.getT1().array()))) {
+            Mono.just(inputStream.readAllBytes()) // signature check placeholder
+                .flatMap(rawBlob -> dispatcher.dispatch(blobName, rawBlob, containerName))
+                .flatMap(blockBlobItem -> Mono.empty()) // delete blob placeholder
+                .subscribe();
+        } catch (IOException exception) {
+            logger.error("Unable to read zip file {} from {} container", blobName, containerName, exception);
+        }
+    }
+
+    // handle unexpected error. will break the processing flow
+    @Override
+    public void onError(Throwable throwable) {
+        logger.error(
+            "Error occurred while processing {} blob from {} container",
+            blobClient.getBlobName(),
+            blobClient.getContainerName(),
+            throwable
+        );
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.blobrouter.tasks.processors;
+
+import com.azure.storage.blob.BlobAsyncClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.specialized.BlobLeaseAsyncClient;
+import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
+import reactor.core.publisher.Mono;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobProcessorSubscriber;
+
+public class BlobProcessor {
+
+    private final BlobServiceAsyncClient storageClient;
+    private final BlobDispatcher dispatcher;
+
+    public BlobProcessor(
+        BlobServiceAsyncClient storageClient,
+        BlobDispatcher dispatcher
+    ) {
+        this.storageClient = storageClient;
+        this.dispatcher = dispatcher;
+    }
+
+    public void process(BlobItem blob, String containerName) {
+        String blobName = blob.getName();
+        BlobAsyncClient blobClient = storageClient
+            .getBlobContainerAsyncClient(containerName)
+            .getBlobAsyncClient(blobName);
+        BlobLeaseAsyncClient blobLeaseClient = new BlobLeaseClientBuilder()
+            .blobAsyncClient(blobClient)
+            .buildAsyncClient();
+
+        Mono<String> lease = blobLeaseClient.acquireLease(60); // parameter: seconds between 15 and 60
+
+        blobClient
+            .download()
+            .zipWith(lease)
+            .subscribe(new BlobProcessorSubscriber(
+                blobClient,
+                blobLeaseClient,
+                dispatcher
+            ));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create blob processing component](https://tools.hmcts.net/jira/browse/BPS-919)

### Change description ###

The main composer class which step-by-step processes single blob. Blob clients are strictly per blob so each time this class will have to constructed - not beaned up.

Should contain error handler in the future so that only serious errors are logged and therefore - break the chain of blob processing from the container

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
