### PR TITLE
Add method for finding envelope by filename and container

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImplTest.java
@@ -135,6 +135,37 @@ public class EnvelopeRepositoryImplTest {
         });
     }
 
+    @Test
+    void should_find_envelopes_by_container_and_file_name() {
+        // given
+        final String fileName = "foo.bar";
+        final String container = "bar";
+
+        // and
+        repo.insert(new NewEnvelope(container, fileName, now(), now(), Status.DISPATCHED));
+
+        // when
+        Optional<Envelope> result = repo.find(fileName, container);
+
+        // then
+        assertThat(result).hasValueSatisfying(envelope -> {
+            assertThat(envelope.fileName).isEqualTo(fileName);
+            assertThat(envelope.container).isEqualTo(container);
+        });
+    }
+
+    @Test
+    void should_return_empty_optional_when_envelope_for_given_container_and_file_name_does_not_exist() {
+        // given
+        repo.insert(new NewEnvelope("a", "b", now(), now(), Status.DISPATCHED));
+
+        // when
+        Optional<Envelope> result = repo.find("some_other_file_name", "some_other_container");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
     private NewEnvelope newEnvelope(Status status) {
         return new NewEnvelope(
             "container",

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepository.java
@@ -5,11 +5,14 @@ import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface EnvelopeRepository {
 
     List<Envelope> find(Status status, boolean isDeleted);
+
+    Optional<Envelope> find(String fileName, String container);
 
     /**
      * Creates new envelope in DB. 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImpl.java
@@ -37,6 +37,23 @@ public class EnvelopeRepositoryImpl implements EnvelopeRepository {
         }
     }
 
+    public Optional<Envelope> find(String fileName, String container) {
+        try {
+            Envelope envelope = jdbcTemplate.queryForObject(
+                "SELECT * FROM envelopes"
+                    + " WHERE file_name = :fileName"
+                    + " AND container = :container",
+                new MapSqlParameterSource()
+                    .addValue("fileName", fileName)
+                    .addValue("container", container),
+                this.mapper
+            );
+            return Optional.of(envelope);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+
     @Override
     public List<Envelope> find(Status status, boolean isDeleted) {
         return jdbcTemplate.query(


### PR DESCRIPTION
As requested by Leszek.
This will be used when processing blobs to check whether file should be skipped or not.