### PR TITLE
Provide connection strings for destination storage accounts

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -40,6 +40,9 @@ java:
     FLYWAY_USER: "{{ .Values.postgresql.postgresqlUsername}}"
     FLYWAY_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
+
+    STORAGE_BULKSCAN_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_BULKSCAN_ACCOUNT_NAME);AccountKey=$(STORAGE_BULKSCAN_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
+    STORAGE_CRIME_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_CRIME_ACCOUNT_NAME);AccountKey=$(STORAGE_CRIME_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -13,10 +13,8 @@ java:
         - storage-account-name
         - storage-account-primary-key
         - storage-account-secondary-key
-        - bulkscan-storage-account-name
-        - bulkscan-storage-account-primary-key
-        - crime-storage-account-name
-        - crime-storage-account-primary-key
+        - bulkscan-storage-connection-string
+        - crime-storage-connection-string
         - flyway-password
   environment:
     DB_HOST: blob_router-{{ .Values.global.environment }}.postgres.database.azure.com

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -37,29 +37,18 @@ data "azurerm_key_vault" "reform_scan_key_vault" {
 
 # region: storage secrets from bulk scan
 
-data "azurerm_key_vault_secret" "bulk_scan_storage_account_name" {
+data "azurerm_key_vault_secret" "bulk_scan_storage_connection_string" {
   key_vault_id = "${data.azurerm_key_vault.bulk_scan_key_vault.id}"
-  name         = "storage-account-name"
-}
-
-data "azurerm_key_vault_secret" "bulk_scan_storage_account_primary_key" {
-  key_vault_id = "${data.azurerm_key_vault.bulk_scan_key_vault.id}"
-  name         = "storage-account-primary-key"
+  name         = "storage-account-connection-string"
 }
 
 # endregion
 
 # region: copy CFT storage account secrets from bulk-scan key vault to reform-scan key vault
 
-resource "azurerm_key_vault_secret" "bulkscan_storage_account_name" {
-  name         = "bulkscan-storage-account-name"
-  value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_name.value}"
-  key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-}
-
-resource "azurerm_key_vault_secret" "bulkscan_storage_account_primary_key" {
-  name         = "bulkscan-storage-account-primary-key"
-  value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_account_primary_key.value}"
+resource "azurerm_key_vault_secret" "bulkscan_storage_connection_string" {
+  name         = "bulkscan-storage-connection-string"
+  value        = "${data.azurerm_key_vault_secret.bulk_scan_storage_connection_string.value}"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
 }
 

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -13,9 +13,7 @@ spring:
         storage-account-name: storage.account-name
         storage-account-primary-key:  storage.account-key
         storage-account-secondary-key:  storage.account-secondary-key
-        bulkscan-storage-account-name: storage.bulkscan.account-name
-        bulkscan-storage-account-primary-key:  storage.bulkscan.account-key
-        crime-storage-account-name: storage.crime.account-name
-        crime-storage-account-primary-key: storage.crime.account-key
+        bulkscan-storage-connection-string: storage.bulkscan.connection-string
+        crime-storage-connection-string: storage.crime.connection-string
         flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-972

### Change description ###

Provide connection strings for destination storage accounts, instead of account names and account keys. The reason behind it is that we're going to have to use connection strings for Crime (which don't have to be based on account key) and for consistency it would be best to do the same for CFT.

Related PR in bulk-scan-shared-infrastructure: https://github.com/hmcts/bulk-scan-shared-infrastructure/pull/153

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
