### PR TITLE
Add storage account client beans for Bulk Scan and Crime

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/clients/ErrorNotificationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/clients/ErrorNotificationClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.created;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 @AutoConfigureWireMock(port = 0)
+@ActiveProfiles("integration-test")
 @SpringBootTest(properties = "clients.error-notifications.url=http://localhost:${wiremock.server.port}")
 public class ErrorNotificationClientTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.blobrouter.config;
+
+import com.azure.storage.common.StorageSharedKeyCredential;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfiguration {
+
+    @Bean
+    public StorageSharedKeyCredential getStorageSharedKeyCredential(
+        @Value("${storage.account-name}") String accountName,
+        @Value("${storage.account-key}") String accountKey
+    ) {
+        return new StorageSharedKeyCredential(accountName, accountKey);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerPublisher.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerPublisher.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.OutputStream;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Built-in feature which saves service's swagger specs in temporary directory.
  * Each travis run on master should automatically save and upload (if updated) documentation.
  */
+@ActiveProfiles("integration-test")
 @SpringBootTest
 @AutoConfigureMockMvc
 class SwaggerPublisher {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImplTest.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 import static java.time.Instant.now;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("db-test")
+@ActiveProfiles({"integration-test", "db-test"})
 @SpringBootTest
 public class EnvelopeRepositoryImplTest {
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.config;
 
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -14,5 +16,19 @@ public class StorageConfiguration {
         @Value("${storage.account-key}") String accountKey
     ) {
         return new StorageSharedKeyCredential(accountName, accountKey);
+    }
+
+    @Bean("bulkscan-storage-client")
+    public static BlobServiceClient getBulkScanStorageClient(
+        @Value("storage.bulkscan.connection-string") String connectionString
+    ) {
+        return new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
+    }
+
+    @Bean("crime-storage-client")
+    public static BlobServiceClient getCrimeStorageClient(
+        @Value("storage.crime.connection-string") String connectionString
+    ) {
+        return new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -22,14 +22,14 @@ public class StorageConfiguration {
 
     @Bean("bulkscan-storage-client")
     public static BlobServiceClient getBulkScanStorageClient(
-        @Value("storage.bulkscan.connection-string") String connectionString
+        @Value("${storage.bulkscan.connection-string}") String connectionString
     ) {
         return new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
     }
 
     @Bean("crime-storage-client")
     public static BlobServiceClient getCrimeStorageClient(
-        @Value("storage.crime.connection-string") String connectionString
+        @Value("${storage.crime.connection-string}") String connectionString
     ) {
         return new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -6,8 +6,10 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile({"!integration-test"})
 public class StorageConfiguration {
 
     @Bean


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-972

### Change description ###

Add storage account client beans for Bulk Scan and Crime.

Relies on https://github.com/hmcts/blob-router-service/pull/90.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
