### PR TITLE
Change chart version to 0.0.13

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net


### PR DESCRIPTION
### Change description ###

Change chart version to 0.0.13.The reason behind it is that due to merge issues, chart version wasn't bumped last time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
