### PR TITLE
Fixed flyway url as it was referring to incorrect host

### DIFF
--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -24,7 +24,7 @@ java:
     DB_USER: blob_router@reform-scan-blob-router-{{ .Values.global.environment }}
     DB_CONN_OPTIONS: ?sslmode=require
 
-    FLYWAY_URL: jdbc:postgresql://blob_router-{{ .Values.global.environment }}.postgres.database.azure.com:5432/blob_router?sslmode=require
+    FLYWAY_URL: jdbc:postgresql://reform-scan-blob-router-{{ .Values.global.environment }}.postgres.database.azure.com:5432/blob_router?sslmode=require
     FLYWAY_USER: blob_router@reform-scan-blob-router-{{ .Values.global.environment }}
     FLYWAY_SKIP_MIGRATIONS: true
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30


### PR DESCRIPTION

### Change description ###

- Flyway was throwing an exception on application boot as the DB host is incorrect.
```
Caused by: org.flywaydb.core.internal.exception.FlywaySqlException:
Unable to obtain connection from database: FATAL: password authentication failed for user "blob_router"
```

- Chart version is not bumped as previous releases have failed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
