### PR TITLE
Add url for main storage client to work

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -28,8 +28,14 @@ public class StorageConfiguration {
     }
 
     @Bean("storage-client")
-    public BlobServiceClient getStorageClient(StorageSharedKeyCredential credentials) {
-        return new BlobServiceClientBuilder().credential(credentials).buildClient();
+    public BlobServiceClient getStorageClient(
+        StorageSharedKeyCredential credentials,
+        @Value("${storage.url}") String storageUrl
+    ) {
+        return new BlobServiceClientBuilder()
+            .credential(credentials)
+            .endpoint(storageUrl)
+            .buildClient();
     }
 
     @Bean("bulkscan-storage-client")


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create blob processing component](https://tools.hmcts.net/jira/browse/BPS-919)

### Change description ###

Setting endpoint to storage client. This is mandatory as library doesn't build from from credentials which has all properties needed to build endpoint. Right now we end up with this error:

> java.net.MalformedURLException: no protocol: /bulkscan no protocol: /bulkscan

when trying to get container client

Value is set during this PR: #123 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
