### PR TITLE
Proposal: retrieve blob storage clients dynamically

### DIFF
--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -17,3 +17,5 @@ spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/blob_router
 storage-blob-processing-delay-in-minutes=0
 
 scheduling.task.scan.enabled=false
+
+bulk-scan-processor-url=false

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
@@ -14,7 +14,7 @@ public class BulkScanProcessorClient {
 
     public BulkScanProcessorClient(
         RestTemplate restTemplate,
-        @Value("bulk-scan-processor-url") String bulkScanProcessorUrl
+        @Value("${bulk-scan-processor-url}") String bulkScanProcessorUrl
     ) {
         System.out.println("bulkScanProcessorUrl " + bulkScanProcessorUrl);
         this.restTemplate = restTemplate;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.blobrouter.clients;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class BulkScanProcessorClient {
+
+    private final RestTemplate restTemplate;
+
+    private final String bulkScanProcessorUrl;
+
+    public BulkScanProcessorClient(RestTemplate restTemplate, @Value("bulk-scan-processor-url") String bulkScanProcessorUrl) {
+
+        System.out.println("bulkScanProcessorUrl " + bulkScanProcessorUrl);
+        this.restTemplate = restTemplate;
+        this.bulkScanProcessorUrl = bulkScanProcessorUrl;
+    }
+
+
+    public SasTokenResponse getSasToken(String container) {
+
+        String url =
+            UriComponentsBuilder
+                .fromHttpUrl(bulkScanProcessorUrl)
+                .path("/token")
+                .path(container)
+                .build()
+                .toString();
+
+        return restTemplate.getForObject(url, SasTokenResponse.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/BulkScanProcessorClient.java
@@ -12,8 +12,10 @@ public class BulkScanProcessorClient {
 
     private final String bulkScanProcessorUrl;
 
-    public BulkScanProcessorClient(RestTemplate restTemplate, @Value("bulk-scan-processor-url") String bulkScanProcessorUrl) {
-
+    public BulkScanProcessorClient(
+        RestTemplate restTemplate,
+        @Value("bulk-scan-processor-url") String bulkScanProcessorUrl
+    ) {
         System.out.println("bulkScanProcessorUrl " + bulkScanProcessorUrl);
         this.restTemplate = restTemplate;
         this.bulkScanProcessorUrl = bulkScanProcessorUrl;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/SasTokenResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/clients/SasTokenResponse.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.blobrouter.clients;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SasTokenResponse {
+
+    @JsonProperty("sas_token")
+    public final String sasToken;
+
+    public SasTokenResponse(String sasToken) {
+        this.sasToken = sasToken;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProvider.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.blobrouter.clients.BulkScanProcessorClient;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
+
+@Service
+public class BlobServiceClientProvider {
+
+    private final BlobServiceClient crimeClient;
+    private final BulkScanProcessorClient bulkScanSasTokenClient;
+    private final String bulkScanStorageUrl;
+
+    public BlobServiceClientProvider(
+        @Qualifier("crime-storage-client") BlobServiceClient crimeClient,
+        BulkScanProcessorClient bulkScanSasTokenClient,
+        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl
+    ) {
+        this.crimeClient = crimeClient;
+        this.bulkScanSasTokenClient = bulkScanSasTokenClient;
+        this.bulkScanStorageUrl = bulkScanStorageUrl;
+    }
+
+    public BlobServiceClient get(TargetStorageAccount targetStorageAccount, String containerName) {
+        switch (targetStorageAccount) {
+            case BULKSCAN:
+                return new BlobServiceClientBuilder()
+                    .sasToken(bulkScanSasTokenClient.getSasToken(containerName).sasToken)
+                    .endpoint(bulkScanStorageUrl)
+                    .buildClient();
+            case CRIME:
+                return crimeClient;
+            default:
+                throw new RuntimeException(
+                    String.format("Client requested for an unknown storage account: %s", targetStorageAccount)
+                );
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -7,6 +7,7 @@ import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
@@ -79,7 +80,8 @@ public class BlobProcessor {
                 leaseClient.acquireLease(60);
                 byte[] rawBlob = tryToDownloadBlob(blobClient);
 
-                dispatcher.dispatch(blobName, rawBlob, containerName);
+                // target storage account will be retrieved from configuration when Crime blob processing is supported
+                dispatcher.dispatch(blobName, rawBlob, containerName, TargetStorageAccount.BULKSCAN);
                 UUID envelopeId = envelopeRepository.insert(createNewEnvelope(
                     blobName,
                     containerName,


### PR DESCRIPTION
### Change description ###

This PR will not go to master - it's just a proposal to be verified by the team.

Background: crime storage client doesn't change - we can use the same one throughout the whole life of the application. Bulk scan storage client, however, is built based on SAS tokens, which expire every few hours. Therefore, bulk scan clients need to be provided dynamically and crime needs to fit in the existing solution.

I've based this PR on https://github.com/hmcts/blob-router-service/pull/119, which contains SAS token endpoint client.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
