### PR TITLE
Provide blob storage clients dynamically

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -24,7 +24,7 @@ def vaultSecrets = [
     secret('storage-account-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
     secret('storage-account-name', 'TEST_STORAGE_ACCOUNT_NAME'),
 
-    secret('bulkscan-storage-connection-string', 'STORAGE_BULKSCAN_CONNECTION_STRING'),
+    secret('bulkscan-storage-account-name', 'STORAGE_BULKSCAN_ACCOUNT_NAME'),
     secret('crime-storage-connection-string', 'STORAGE_CRIME_CONNECTION_STRING')
   ]
 ]
@@ -72,6 +72,7 @@ withPipeline(type, product, component) {
   // Vars needed for smoke / functional testing
   env.TEST_STORAGE_CONTAINER_NAME = 'bulkscan'
   env.TEST_STORAGE_ACCOUNT_URL = 'https://reformscan.aat.platform.hmcts.net'
+  env.STORAGE_BULKSCAN_URL = 'https://bulkscan.aat.platform.hmcts.net'
 
   before('smoketest:preview') {
     withAksClient('nonprod') {
@@ -91,10 +92,8 @@ withPipeline(type, product, component) {
       env.TEST_STORAGE_ACCOUNT_URL = "https://${env.TEST_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
       env.TEST_STORAGE_ACCOUNT_KEY = previewAccountKey(kubectl, storageSecret, namespace)
 
-      env.STORAGE_BULKSCAN_CONNECTION_STRING = storageAccountConnectionString(
-        previewAccountName(kubectl, bulkScanStorageAccountSecret, namespace),
-        previewAccountKey(kubectl, bulkScanStorageAccountSecret, namespace)
-      )
+      def bulkScanStorageAccountName = previewAccountName(kubectl, bulkScanStorageAccountSecret, namespace)
+      env.STORAGE_BULKSCAN_URL = "https://${bulkScanStorageAccountName}.blob.core.windows.net"
 
       env.STORAGE_CRIME_CONNECTION_STRING = storageAccountConnectionString(
         previewAccountName(kubectl, crimeStorageAccountSecret, namespace),

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.18
+version: 0.0.19
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -44,7 +44,7 @@ java:
     FLYWAY_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
 
-    STORAGE_BULKSCAN_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_BULKSCAN_ACCOUNT_NAME);AccountKey=$(STORAGE_BULKSCAN_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
+    STORAGE_BULKSCAN_URL: "https://$(STORAGE_BULKSCAN_ACCOUNT_NAME).blob.core.windows.net"
     STORAGE_CRIME_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_CRIME_ACCOUNT_NAME);AccountKey=$(STORAGE_CRIME_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
   # Don't modify below here
   image: ${IMAGE_NAME}

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -13,7 +13,6 @@ java:
         - storage-account-name
         - storage-account-primary-key
         - storage-account-secondary-key
-        - bulkscan-storage-connection-string
         - crime-storage-connection-string
         - flyway-password
         - blob-router-POSTGRES-PASS
@@ -32,6 +31,7 @@ java:
     TASK_SCAN_DELAY: "4000" # in millis
 
     STORAGE_URL: https://reformscan.{{ .Values.global.environment }}.platform.hmcts.net
+    STORAGE_BULKSCAN_URL: https://bulkscan.{{ .Values.global.environment }}.platform.hmcts.net
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
     CRIME_DESTINATION_CONTAINER: bs-sit-scans-received
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/config/TestConfiguration.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/config/TestConfiguration.java
@@ -9,7 +9,7 @@ public class TestConfiguration {
     public final String sourceStorageAccountKey;
     public final String sourceStorageAccountUrl;
 
-    public final String bulkScanStorageConnectionString;
+    public final String bulkScanStorageUrl;
     public final String crimeStorageConnectionString;
 
     public final String crimeDestinationContainer;
@@ -22,7 +22,7 @@ public class TestConfiguration {
         this.sourceStorageAccountKey = config.getString("source-storage-account-key");
         this.sourceStorageAccountUrl = config.getString("source-storage-account-url");
 
-        this.bulkScanStorageConnectionString = config.getString("bulkscan-storage-connection-string");
+        this.bulkScanStorageUrl = config.getString("bulkscan-storage-url");
 
         this.crimeStorageConnectionString = config.getString("crime-storage-connection-string");
         this.crimeDestinationContainer = config.getString("crime-source-container");

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -2,7 +2,7 @@ source-storage-account-name=${TEST_STORAGE_ACCOUNT_NAME}
 source-storage-account-key=${TEST_STORAGE_ACCOUNT_KEY}
 source-storage-account-url=${TEST_STORAGE_ACCOUNT_URL}
 
-bulkscan-storage-connection-string=${STORAGE_BULKSCAN_CONNECTION_STRING}
+bulkscan-storage-url=${STORAGE_BULKSCAN_URL}
 crime-storage-connection-string=${STORAGE_CRIME_CONNECTION_STRING}
 
 crime-source-container=crime

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerExceptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerExceptionTest.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.blobrouter.controllers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobServiceClientProvider;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -23,6 +25,9 @@ public class SasTokenControllerExceptionTest extends ControllerTestBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private BlobServiceClientProvider blobServiceClientProvider;
 
     @Test
     public void should_throw_exception_when_storage_is_not_configured() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerTest.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobServiceClientProvider;
 
 import java.util.Map;
 
@@ -25,6 +27,9 @@ public class SasTokenControllerTest extends ControllerTestBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private BlobServiceClientProvider blobServiceClientProvider;
 
     @Test
     public void should_generate_sas_token_when_service_is_configured() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
 
 class BlobDispatcherTest extends TestBase {
 
@@ -25,21 +29,23 @@ class BlobDispatcherTest extends TestBase {
 
     @Override
     protected void beforeTest() {
+        BlobServiceClientProvider blobServiceClientProvider = mock(BlobServiceClientProvider.class);
         BlobServiceClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
-        dispatcher = new BlobDispatcher(storageClient);
+        given(blobServiceClientProvider.get(any(), any())).willReturn(storageClient);
+        dispatcher = new BlobDispatcher(blobServiceClientProvider);
     }
 
     @Test
     void should_upload_blob_to_dedicated_container() {
         assertThatCode(() -> dispatcher
-            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER)
+            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), DESTINATION_CONTAINER, BULKSCAN)
         ).doesNotThrowAnyException();
     }
 
     @Test
     void should_catch_BlobStorageException_and_suppress_it() {
         assertThatCode(() -> dispatcher
-            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), BOGUS_CONTAINER)
+            .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), BOGUS_CONTAINER, BULKSCAN)
         ).doesNotThrowAnyException();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -10,10 +10,14 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.services.BlobReadinessChecker;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
+import uk.gov.hmcts.reform.blobrouter.services.storage.BlobServiceClientProvider;
 import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseClientProvider;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ActiveProfiles("db-test")
 @SpringBootTest
@@ -43,7 +47,9 @@ class ContainerProcessorTest extends TestBase {
     @Override
     protected void beforeTest() {
         BlobServiceClient storageClient = StorageClientsHelper.getStorageClient(interceptorManager);
-        BlobDispatcher dispatcher = new BlobDispatcher(storageClient);
+        BlobServiceClientProvider blobServiceClientProvider = mock(BlobServiceClientProvider.class);
+        given(blobServiceClientProvider.get(any(), any())).willReturn(storageClient);
+        BlobDispatcher dispatcher = new BlobDispatcher(blobServiceClientProvider);
         BlobProcessor blobProcessor = new BlobProcessor(
             storageClient,
             dispatcher,

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -18,6 +18,7 @@ storage-blob-processing-delay-in-minutes=0
 
 scheduling.task.scan.enabled=false
 
+storage.bulkscan.url=http://localhost
 bulk-scan-processor-url=http://localhost
 scheduling.task.delete-dispatched-files.enabled: false
 scheduling.task.delete-dispatched-files.cron: 0/10 * * * * *

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -38,13 +38,6 @@ public class StorageConfiguration {
             .buildClient();
     }
 
-    @Bean("bulkscan-storage-client")
-    public static BlobServiceClient getBulkScanStorageClient(
-        @Value("${storage.bulkscan.connection-string}") String connectionString
-    ) {
-        return new BlobServiceClientBuilder().connectionString(connectionString).buildClient();
-    }
-
     @Bean("crime-storage-client")
     public static BlobServiceClient getCrimeStorageClient(
         @Value("${storage.crime.connection-string}") String connectionString

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.blobrouter.services.storage;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
@@ -17,9 +16,7 @@ public class BlobDispatcher {
 
     private final BlobServiceClient bulkscanStorageClient;
 
-    public BlobDispatcher(
-        @Qualifier("bulkscan-storage-client") BlobServiceClient bulkscanStorageClient
-    ) {
+    public BlobDispatcher(BlobServiceClient bulkscanStorageClient) {
         this.bulkscanStorageClient = bulkscanStorageClient;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 
 import java.io.ByteArrayInputStream;
 
@@ -14,17 +14,22 @@ public class BlobDispatcher {
 
     private static final Logger logger = getLogger(BlobDispatcher.class);
 
-    private final BlobServiceClient bulkscanStorageClient;
+    private final BlobServiceClientProvider blobServiceClientProvider;
 
-    public BlobDispatcher(BlobServiceClient bulkscanStorageClient) {
-        this.bulkscanStorageClient = bulkscanStorageClient;
+    public BlobDispatcher(BlobServiceClientProvider blobServiceClientProvider) {
+        this.blobServiceClientProvider = blobServiceClientProvider;
     }
 
-    public void dispatch(String blobName, byte[] blobContents, String destinationContainer) {
-        logger.info("Uploading {} to {} container", blobName, destinationContainer);
+    public void dispatch(
+        String blobName,
+        byte[] blobContents,
+        String destinationContainer,
+        TargetStorageAccount targetStorageAccount
+    ) {
+        logger.info("Uploading {} to {} container. Storage: {}", blobName, destinationContainer, targetStorageAccount);
 
         try {
-            getContainerClient(destinationContainer)
+            getContainerClient(targetStorageAccount, destinationContainer)
                 .getBlobClient(blobName)
                 .getBlockBlobClient()
                 .upload(
@@ -32,19 +37,30 @@ public class BlobDispatcher {
                     blobContents.length
                 );
 
-            logger.info("Finished uploading {} to {} container", blobName, destinationContainer);
-        } catch (Exception exception) {
-            logger.error(
-                "Error occurred while uploading {} to {} container",
+            logger.info(
+                "Finished uploading {} to {} container. Storage: {}",
                 blobName,
                 destinationContainer,
-                exception
+                targetStorageAccount
+            );
+        } catch (Exception exception) {
+            logger.error(
+                "Error occurred while uploading {} to {} container. Storage: {}",
+                blobName,
+                destinationContainer,
+                exception,
+                targetStorageAccount
             );
         }
     }
 
     // will use different storageClient depending on container
-    private BlobContainerClient getContainerClient(String destinationContainer) {
-        return bulkscanStorageClient.getBlobContainerClient(destinationContainer);
+    private BlobContainerClient getContainerClient(
+        TargetStorageAccount targetStorageAccount,
+        String destinationContainer
+    ) {
+        return blobServiceClientProvider
+            .get(targetStorageAccount, destinationContainer)
+            .getBlobContainerClient(destinationContainer);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProvider.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.blobrouter.clients.bulkscanprocessor.BulkScanProcessorClient;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
+
+@Service
+public class BlobServiceClientProvider {
+
+    private final BlobServiceClient crimeClient;
+    private final BulkScanProcessorClient bulkScanSasTokenClient;
+    private final String bulkScanStorageUrl;
+
+    public BlobServiceClientProvider(
+        @Qualifier("crime-storage-client") BlobServiceClient crimeClient,
+        BulkScanProcessorClient bulkScanSasTokenClient,
+        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl
+    ) {
+        this.crimeClient = crimeClient;
+        this.bulkScanSasTokenClient = bulkScanSasTokenClient;
+        this.bulkScanStorageUrl = bulkScanStorageUrl;
+    }
+
+    public BlobServiceClient get(TargetStorageAccount targetStorageAccount, String containerName) {
+        switch (targetStorageAccount) {
+            case BULKSCAN:
+                // retrieving a SAS token every time we're getting a client, but this will be cached in the future
+                return new BlobServiceClientBuilder()
+                    .sasToken(bulkScanSasTokenClient.getSasToken(containerName).sasToken)
+                    .endpoint(bulkScanStorageUrl)
+                    .buildClient();
+            case CRIME:
+                return crimeClient;
+            default:
+                throw new UnknownStorageAccountException(
+                    String.format("Client requested for an unknown storage account: %s", targetStorageAccount)
+                );
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/UnknownStorageAccountException.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/UnknownStorageAccountException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+public class UnknownStorageAccountException extends RuntimeException {
+
+    public UnknownStorageAccountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -7,6 +7,7 @@ import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
@@ -79,7 +80,8 @@ public class BlobProcessor {
                 leaseClient.acquireLease(60);
                 byte[] rawBlob = tryToDownloadBlob(blobClient);
 
-                dispatcher.dispatch(blobName, rawBlob, containerName);
+                // target storage account will be retrieved from configuration when Crime blob processing is supported
+                dispatcher.dispatch(blobName, rawBlob, containerName, TargetStorageAccount.BULKSCAN);
                 UUID envelopeId = envelopeRepository.insert(createNewEnvelope(
                     blobName,
                     containerName,

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -13,7 +13,6 @@ spring:
         storage-account-name: storage.account-name
         storage-account-primary-key:  storage.account-key
         storage-account-secondary-key:  storage.account-secondary-key
-        bulkscan-storage-connection-string: storage.bulkscan.connection-string
         crime-storage-connection-string: storage.crime.connection-string
         flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobServiceClientProviderTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobServiceClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.blobrouter.clients.bulkscanprocessor.BulkScanProcessorClient;
+import uk.gov.hmcts.reform.blobrouter.clients.bulkscanprocessor.SasTokenResponse;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class BlobServiceClientProviderTest {
+
+    @Mock
+    BlobServiceClient crimeClient;
+
+    @Mock
+    BulkScanProcessorClient bulkScanProcessorClient;
+
+    private BlobServiceClientProvider blobServiceClientProvider;
+
+    @BeforeEach
+    private void setUp() {
+        this.blobServiceClientProvider = new BlobServiceClientProvider(
+            crimeClient,
+            bulkScanProcessorClient,
+            "https://example.com"
+        );
+    }
+
+    @Test
+    void should_return_crime_client_for_crime_storage() {
+        BlobServiceClient client = blobServiceClientProvider.get(TargetStorageAccount.CRIME, "crime");
+
+        assertThat(client).isSameAs(crimeClient);
+    }
+
+    @Test
+    void should_retrieve_sas_token_for_bulk_scan_storage() {
+        String containerName = "container123";
+        SasTokenResponse sasTokenResponse = new SasTokenResponse("token1");
+        given(bulkScanProcessorClient.getSasToken(any())).willReturn(sasTokenResponse);
+        BlobServiceClient client = blobServiceClientProvider.get(TargetStorageAccount.BULKSCAN, containerName);
+
+        assertThat(client).isNotNull();
+        verify(bulkScanProcessorClient).getSasToken(containerName);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -64,7 +64,7 @@ class BlobProcessorTest {
 
         // then
         verify(readinessChecker).isReady(eq(blobCreationTime.toInstant()));
-        verify(blobDispatcher, never()).dispatch(any(), any(), any());
+        verify(blobDispatcher, never()).dispatch(any(), any(), any(), any());
     }
 
     @Test
@@ -81,7 +81,7 @@ class BlobProcessorTest {
 
         // then
         verify(readinessChecker).isReady(eq(blobCreationTime.toInstant()));
-        verify(blobDispatcher, times(1)).dispatch(any(), any(), any());
+        verify(blobDispatcher, times(1)).dispatch(any(), any(), any(), any());
     }
 
     private void blobExists(OffsetDateTime time) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-919

### Change description ###

This PR covers the following:
- Provide blob storage clients dynamically to blob dispatcher
- Configuration changes to enable using bulk scan processor blob storage (changes from #130)

These changes are very much related and it's hard to introduce them one after another, as the configuration changes would break the application.

This change will be followed by:
- adjusting the solution to use crime for `crime` container
- functional tests for CFT

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
