### PR TITLE
Remove an unused reference of a missing secret

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -23,8 +23,7 @@ def vaultSecrets = [
 
     secret('storage-account-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
     secret('storage-account-name', 'TEST_STORAGE_ACCOUNT_NAME'),
-
-    secret('bulkscan-storage-account-name', 'STORAGE_BULKSCAN_ACCOUNT_NAME'),
+    
     secret('crime-storage-connection-string', 'STORAGE_CRIME_CONNECTION_STRING')
   ]
 ]


### PR DESCRIPTION
### Change description ###

Remove an unused reference of a missing secret. This is a fix for master build, exactly the same as #132, but there preview build seems to be properly broken.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
