### PR TITLE
Stop BlobDispatcher from catching exceptions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.core.test.TestBase;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobStorageException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.blobrouter.util.StorageClientsHelper;
@@ -43,9 +44,9 @@ class BlobDispatcherTest extends TestBase {
     }
 
     @Test
-    void should_catch_BlobStorageException_and_suppress_it() {
+    void should_rethrow_exceptions() {
         assertThatCode(() -> dispatcher
             .dispatch(NEW_BLOB_NAME, NEW_BLOB_NAME.getBytes(), BOGUS_CONTAINER, BULKSCAN)
-        ).doesNotThrowAnyException();
+        ).isInstanceOf(BlobStorageException.class);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -28,30 +28,20 @@ public class BlobDispatcher {
     ) {
         logger.info("Uploading {} to {} container. Storage: {}", blobName, destinationContainer, targetStorageAccount);
 
-        try {
-            getContainerClient(targetStorageAccount, destinationContainer)
-                .getBlobClient(blobName)
-                .getBlockBlobClient()
-                .upload(
-                    new ByteArrayInputStream(blobContents),
-                    blobContents.length
-                );
+        getContainerClient(targetStorageAccount, destinationContainer)
+            .getBlobClient(blobName)
+            .getBlockBlobClient()
+            .upload(
+                new ByteArrayInputStream(blobContents),
+                blobContents.length
+            );
 
-            logger.info(
-                "Finished uploading {} to {} container. Storage: {}",
-                blobName,
-                destinationContainer,
-                targetStorageAccount
-            );
-        } catch (Exception exception) {
-            logger.error(
-                "Error occurred while uploading {} to {} container. Storage: {}",
-                blobName,
-                destinationContainer,
-                exception,
-                targetStorageAccount
-            );
-        }
+        logger.info(
+            "Finished uploading {} to {} container. Storage: {}",
+            blobName,
+            destinationContainer,
+            targetStorageAccount
+        );
     }
 
     // will use different storageClient depending on container

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -85,7 +85,7 @@ class BlobProcessorTest {
             .dispatch(any(), any(), any(), any());
 
         // when
-        blobProcessor.process("envelope.zip", "container1");
+        blobProcessor.process("envelope1.zip", "container1");
 
         // then
         verify(blobDispatcher).dispatch(eq("envelope1.zip"), any(), eq("container1"), eq(BULKSCAN));


### PR DESCRIPTION
### Change description ###

Stop BlobDispatcher from catching exceptions, so that BlobProcessor doesn't save envelopes when upload failed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
