### PR TITLE
Retrieve dispatched envelopes for currently processed container only

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface EnvelopeRepository {
 
-    List<Envelope> find(Status status, boolean isDeleted);
+    List<Envelope> find(Status status, String container, boolean isDeleted);
 
     Optional<Envelope> find(String fileName, String container);
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryImpl.java
@@ -55,11 +55,12 @@ public class EnvelopeRepositoryImpl implements EnvelopeRepository {
     }
 
     @Override
-    public List<Envelope> find(Status status, boolean isDeleted) {
+    public List<Envelope> find(Status status, String container, boolean isDeleted) {
         return jdbcTemplate.query(
-            "SELECT * FROM envelopes WHERE status = :status AND is_deleted = :isDeleted",
+            "SELECT * FROM envelopes WHERE status = :status AND container = :container AND is_deleted = :isDeleted",
             new MapSqlParameterSource()
                 .addValue("status", status.name())
+                .addValue("container", container)
                 .addValue("isDeleted", isDeleted),
             this.mapper
         );

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
@@ -38,7 +38,7 @@ public class ContainerCleaner {
             final BlobContainerClient containerClient = storageClient.getBlobContainerClient(containerName);
 
             envelopeRepository
-                .find(DISPATCHED, false)
+                .find(DISPATCHED, containerName, false)
                 .forEach(envelope -> {
                     tryToDeleteBlob(envelope, containerClient);
                 });

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
@@ -62,9 +62,9 @@ class ContainerCleanerTest {
     }
 
     @Test
-    void should_not_find_any_blobs() {
+    void should_not_find_any_blobs_when_no_db_results() {
         // given
-        given(envelopeRepository.find(DISPATCHED, false)).willReturn(emptyList());
+        given(envelopeRepository.find(DISPATCHED, CONTAINER_NAME, false)).willReturn(emptyList());
 
         // when
         containerCleaner.process(CONTAINER_NAME);
@@ -76,7 +76,7 @@ class ContainerCleanerTest {
     @Test
     void should_handle_repository_exception() {
         // given
-        given(envelopeRepository.find(DISPATCHED, false)).willThrow(new RuntimeException("msg"));
+        given(envelopeRepository.find(DISPATCHED, CONTAINER_NAME, false)).willThrow(new RuntimeException("msg"));
 
         // when
         containerCleaner.process(CONTAINER_NAME);
@@ -88,7 +88,7 @@ class ContainerCleanerTest {
     @Test
     void should_find_blobs_delete_and_update_in_db() {
         // given
-        given(envelopeRepository.find(DISPATCHED, false))
+        given(envelopeRepository.find(DISPATCHED, CONTAINER_NAME, false))
             .willReturn(asList(
                 ENVELOPE_1,
                 ENVELOPE_2
@@ -106,7 +106,7 @@ class ContainerCleanerTest {
         verifyNoMoreInteractions(containerClient);
         verify(blobClient1).delete();
         verify(blobClient2).delete();
-        verify(envelopeRepository).find(DISPATCHED, false);
+        verify(envelopeRepository).find(DISPATCHED, CONTAINER_NAME, false);
         verify(envelopeRepository).markAsDeleted(ENVELOPE_1.id);
         verify(envelopeRepository).markAsDeleted(ENVELOPE_2.id);
         verifyNoMoreInteractions(envelopeRepository);
@@ -115,7 +115,7 @@ class ContainerCleanerTest {
     @Test
     void should_handle_non_existing_file() {
         // given
-        given(envelopeRepository.find(DISPATCHED, false))
+        given(envelopeRepository.find(DISPATCHED, CONTAINER_NAME, false))
             .willReturn(singletonList(
                 ENVELOPE_1
             ));
@@ -131,7 +131,7 @@ class ContainerCleanerTest {
         verify(containerClient).getBlobContainerName();
         verifyNoMoreInteractions(containerClient);
         verify(blobClient1).delete();
-        verify(envelopeRepository).find(DISPATCHED, false);
+        verify(envelopeRepository).find(DISPATCHED, CONTAINER_NAME, false);
         verify(envelopeRepository).markAsDeleted(ENVELOPE_1.id);
         verifyNoMoreInteractions(envelopeRepository);
     }
@@ -139,7 +139,7 @@ class ContainerCleanerTest {
     @Test
     void should_handle_server_error() {
         // given
-        given(envelopeRepository.find(DISPATCHED, false))
+        given(envelopeRepository.find(DISPATCHED, CONTAINER_NAME, false))
             .willReturn(singletonList(
                 ENVELOPE_1
             ));
@@ -155,7 +155,7 @@ class ContainerCleanerTest {
         verify(containerClient).getBlobContainerName();
         verifyNoMoreInteractions(containerClient);
         verify(blobClient1).delete();
-        verify(envelopeRepository).find(DISPATCHED, false);
+        verify(envelopeRepository).find(DISPATCHED, CONTAINER_NAME, false);
         verifyNoMoreInteractions(envelopeRepository);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-970

### Change description ###

In the deletion task, retrieve dispatched blobs for currently processed container, instead for all containers.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
