### PR TITLE
Revert "Disabled api mgmt to deploy blob router service"

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -61,7 +61,7 @@ withPipeline(type, product, component) {
   enableAksStagingDeployment()
   installCharts()
   enableSlackNotifications(channel)
-  // enableApiGatewayTest()
+  enableApiGatewayTest()
   disableLegacyDeployment()
 
   onNonPR() {


### PR DESCRIPTION
- Reverting this one as the api is now there and we need api mgmt to be deployed.