### PR TITLE
.editorconfig : allow inline field annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,4 @@ ij_java_align_multiline_parameters_in_calls = true
 ij_java_call_parameters_new_line_after_left_paren = true
 ij_java_call_parameters_right_paren_on_new_line = true
 ij_java_call_parameters_wrap = on_every_item
+ij_java_field_annotation_wrap = off


### PR DESCRIPTION
so that stuff like this:
```java
@Mock BlobReadinessChecker readinessChecker;
@Mock BlobServiceClient blobServiceClient;
@Mock BlobContainerClient containerClient;
@Mock BlobClient blobClient;
@Mock BlobProperties blobProperties;
@Mock BlobDispatcher blobDispatcher;
@Mock BlobLeaseClient blobLeaseClient;
@Mock EnvelopeRepository envelopeRepo;

BlobProcessor blobProcessor;
```
is ok, and does not get reformatted automatically to:
```java
@Mock
BlobReadinessChecker readinessChecker;

@Mock 
BlobServiceClient blobServiceClient;

@Mock 
BlobContainerClient containerClient;

@Mock 
BlobClient blobClient;

@Mock 
BlobProperties blobProperties;

@Mock 
BlobDispatcher blobDispatcher;

@Mock 
BlobLeaseClient blobLeaseClient;

@Mock 
EnvelopeRepository envelopeRepo;

BlobProcessor blobProcessor;
```