### PR TITLE
Use java 10 `var` where appropriate

### DIFF
--- a/src/apiGatewayTest/java/uk/gov/hmcts/reform/blobrouter/ApiGatewayTest.java
+++ b/src/apiGatewayTest/java/uk/gov/hmcts/reform/blobrouter/ApiGatewayTest.java
@@ -44,7 +44,7 @@ class ApiGatewayTest {
         // create tmp file for valid certificate retrieved from key vault
         validJavaKeyStore = File.createTempFile("appGW", "test");
 
-        try (FileOutputStream fos = new FileOutputStream(validJavaKeyStore)) {
+        try (var fos = new FileOutputStream(validJavaKeyStore)) {
             fos.write(Base64.getDecoder().decode(CONFIG.getString("client.valid-key-store.content")));
         }
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/FunctionalTestBase.java
@@ -24,7 +24,7 @@ public abstract class FunctionalTestBase {
     protected BlobServiceClient blobRouterStorageClient;
 
     protected void setUp() {
-        StorageSharedKeyCredential blobRouterStorageCredential = new StorageSharedKeyCredential(
+        var blobRouterStorageCredential = new StorageSharedKeyCredential(
             config.sourceStorageAccountName,
             config.sourceStorageAccountKey
         );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/envelope/ZipFileHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/envelope/ZipFileHelper.java
@@ -20,8 +20,8 @@ public final class ZipFileHelper {
     }
 
     public static byte[] createZipArchive(List<String> resourceFilePaths) throws IOException, URISyntaxException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
+        var outputStream = new ByteArrayOutputStream();
+        try (var zos = new ZipOutputStream(outputStream)) {
             for (String filePath : resourceFilePaths) {
                 URL fileUrl = getResource(filePath);
                 String fileName = new File(fileUrl.toURI()).getName();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/clients/bulkscanprocessor/BulkScanProcessorClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/clients/bulkscanprocessor/BulkScanProcessorClientTest.java
@@ -26,7 +26,7 @@ public class BulkScanProcessorClientTest {
     @Test
     public void should_return_sas_token_when_everything_is_ok() throws JsonProcessingException {
 
-        SasTokenResponse expected = new SasTokenResponse("187*2@(*&^%$£@12");
+        var expected = new SasTokenResponse("187*2@(*&^%$£@12");
 
         // given
         stubFor(get("/token/sscs").willReturn(okJson("{\"sas_token\":\"187*2@(*&^%$£@12\"}")));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -29,9 +29,20 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
+    void should_return_empty_optional_if_envelope_does_not_exist() {
+        // given no envelopes in DB
+
+        // when
+        Optional<Envelope> envelope = repo.find(UUID.randomUUID());
+
+        // then
+        assertThat(envelope).isEmpty();
+    }
+
+    @Test
     void should_save_and_read_envelope_by_id() {
         // given
-        NewEnvelope newEnvelope = new NewEnvelope(
+        var newEnvelope = new NewEnvelope(
             "container",
             "hello.zip",
             now(),
@@ -60,7 +71,7 @@ public class EnvelopeRepositoryTest {
     @Test
     void should_mark_existing_envelope_as_deleted() {
         // given
-        NewEnvelope newEnvelope = new NewEnvelope(
+        var newEnvelope = new NewEnvelope(
             "container",
             "hello.zip",
             now(),

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -29,17 +29,6 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_return_empty_optional_if_envelope_does_not_exist() {
-        // given no envelopes in DB
-
-        // when
-        Optional<Envelope> envelope = repo.find(UUID.randomUUID());
-
-        // then
-        assertThat(envelope).isEmpty();
-    }
-
-    @Test
     void should_save_and_read_envelope_by_id() {
         // given
         var newEnvelope = new NewEnvelope(

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
@@ -47,7 +47,7 @@ public class SasTokenGeneratorService {
     private BlobServiceSasSignatureValues getBlobServiceSasSignatureValues(String serviceName) {
         StorageConfig config = getConfigForService(serviceName);
 
-        BlobContainerSasPermission permissions = new BlobContainerSasPermission()
+        var permissions = new BlobContainerSasPermission()
             .setListPermission(true)
             .setWritePermission(true);
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -109,7 +109,7 @@ public class BlobProcessor {
     }
 
     private byte[] tryToDownloadBlob(BlobClient blobClient) throws IOException {
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+        try (var outputStream = new ByteArrayOutputStream()) {
             blobClient.download(outputStream);
 
             return outputStream.toByteArray();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobReadinessCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobReadinessCheckerTest.java
@@ -12,7 +12,7 @@ class BlobReadinessCheckerTest {
     @Test
     void should_only_allow_processing_files_after_required_time_passed() {
         int delayInMinutes = 10;
-        BlobReadinessChecker checker = new BlobReadinessChecker(delayInMinutes);
+        var checker = new BlobReadinessChecker(delayInMinutes);
 
         assertThat(checker.isReady(now().minus(0, MINUTES))).isFalse();
         assertThat(checker.isReady(now().minus(5, MINUTES))).isFalse();
@@ -23,7 +23,7 @@ class BlobReadinessCheckerTest {
 
     @Test
     void should_allow_processing_all_files_if_delay_is_set_to_zero() {
-        BlobReadinessChecker checker = new BlobReadinessChecker(0);
+        var checker = new BlobReadinessChecker(0);
 
         assertThat(checker.isReady(now().minus(0, MINUTES))).isTrue();
         assertThat(checker.isReady(now().minus(5, MINUTES))).isTrue();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
@@ -34,7 +34,7 @@ class SasTokenGeneratorServiceTest {
             )
         );
 
-        StorageSharedKeyCredential storageCredentials = new StorageSharedKeyCredential(
+        var storageCredentials = new StorageSharedKeyCredential(
             "testAccountName", "dGVzdGtleQ=="
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
@@ -45,7 +45,7 @@ public class BlobContainerClientProviderTest {
     @Test
     void should_retrieve_sas_token_for_bulk_scan_storage() {
         String containerName = "container123";
-        SasTokenResponse sasTokenResponse = new SasTokenResponse("token1");
+        var sasTokenResponse = new SasTokenResponse("token1");
         given(bulkScanProcessorClient.getSasToken(any())).willReturn(sasTokenResponse);
         BlobContainerClient client = blobContainerClientProvider.get(TargetStorageAccount.BULKSCAN, containerName);
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
@@ -30,7 +30,7 @@ class BlobDispatcherTaskTest {
     @Test
     void should_get_all_containers_but_process_only_available_ones() {
         // given
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        var serviceConfiguration = new ServiceConfiguration();
         serviceConfiguration.setStorageConfig(
             asList(
                 configure("bulkscan", true),
@@ -50,7 +50,7 @@ class BlobDispatcherTaskTest {
     @Test
     void should_not_call_container_processor_when_no_available_containers_found() {
         // given
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        var serviceConfiguration = new ServiceConfiguration();
         serviceConfiguration.setStorageConfig(
             asList(
                 configure("bulkscan", false),

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
@@ -28,7 +28,7 @@ class DeleteDispatchedFilesTaskTest {
     @Test
     void should_process_all_enabled_containers_and_should_not_process_any_disabled_container() {
         // given
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        var serviceConfiguration = new ServiceConfiguration();
         serviceConfiguration.setStorageConfig(
             asList(
                 configure("bulkscan", true),
@@ -49,7 +49,7 @@ class DeleteDispatchedFilesTaskTest {
     @Test
     void should_not_call_container_processor_when_no_available_containers_found() {
         // given
-        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        var serviceConfiguration = new ServiceConfiguration();
         serviceConfiguration.setStorageConfig(
             asList(
                 configure("bulkscan", false),

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/DirectoryZipper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/DirectoryZipper.java
@@ -47,8 +47,8 @@ final class DirectoryZipper {
     }
 
     private static byte[] zipItems(List<ZipItem> items) throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
+        var outputStream = new ByteArrayOutputStream();
+        try (var zos = new ZipOutputStream(outputStream)) {
 
             for (ZipItem item : items) {
                 zos.putNextEntry(new ZipEntry(item.name));


### PR DESCRIPTION
Use `var` in places where type of variable is known and declaring it adds no value (is duplicated)
Ie replacing things like:
```java
SomeClassName someClassName = new SomeClassName(...)
```
with
```java
var someClassName = new SomeClassName(...)
```

at least in the places that were easy to find...