### PR TITLE
Use Java9 Set instead of Guava's Set

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.blobrouter.util;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -86,7 +85,7 @@ class ZipVerifiersTest {
 
     @Test
     void should_verify_2_valid_filenames_successfully() {
-        Set<String> files = ImmutableSet.of(
+        Set<String> files = Set.of(
             ZipVerifiers.DOCUMENTS_ZIP,
             ZipVerifiers.SIGNATURE_SIG
         );
@@ -96,7 +95,7 @@ class ZipVerifiersTest {
 
     @Test
     void should_not_verify_more_than_2_files_successfully() {
-        Set<String> files = ImmutableSet.of(
+        Set<String> files = Set.of(
             ZipVerifiers.DOCUMENTS_ZIP,
             ZipVerifiers.SIGNATURE_SIG,
             "signature2"
@@ -109,7 +108,7 @@ class ZipVerifiersTest {
 
     @Test
     void should_not_verify_invalid_filenames_successfully() {
-        Set<String> files = ImmutableSet.of(
+        Set<String> files = Set.of(
             ZipVerifiers.DOCUMENTS_ZIP,
             "signature.sig"
         );


### PR DESCRIPTION
Java 9 introduced new way of creating (immutable) set.
No need to use Guava for that.

https://docs.oracle.com/javase/9/core/creating-immutable-lists-sets-and-maps.htm#JSCOR-GUID-DB0865D2-C052-40BC-A3DC-20FCB3088DC9