### PR TITLE
Track schedules as requests in App Insights

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.blobrouter.config;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,10 +22,9 @@ public class StorageConfiguration {
         return new StorageSharedKeyCredential(accountName, accountKey);
     }
 
-    // not used as needs test context so it can actually be build
-    @Bean()
+    @Bean
     public BlobServiceClient getStorageClient(StorageSharedKeyCredential credentials) {
-        return new BlobServiceClientBuilder().credential(credentials).buildClient();
+        return mock(BlobServiceClient.class);
     }
 
     @Bean("crime-storage-client")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerPublisher.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerPublisher.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.blobrouter.config;
 
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
 
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -14,6 +18,7 @@ import java.nio.file.Paths;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 /**
  * Built-in feature which saves service's swagger specs in temporary directory.
@@ -26,6 +31,16 @@ class SwaggerPublisher {
 
     @Autowired
     private MockMvc mvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
+        filter.init(new MockFilterConfig());
+        mvc = webAppContextSetup(wac).addFilters(filter).build();
+    }
 
     @DisplayName("Generate swagger documentation")
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.reform.blobrouter.controllers;
 
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
@@ -22,6 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -29,6 +34,16 @@ public class EnvelopeControllerTest extends ControllerTestBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
+        filter.init(new MockFilterConfig());
+        mockMvc = webAppContextSetup(wac).addFilters(filter).build();
+    }
 
     @Test
     void should_find_envelope_by_file_name_and_container_if_it_exists() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerExceptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerExceptionTest.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.blobrouter.controllers;
 
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProvider;
 
@@ -14,6 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -25,6 +30,16 @@ public class SasTokenControllerExceptionTest extends ControllerTestBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
+        filter.init(new MockFilterConfig());
+        mockMvc = webAppContextSetup(wac).addFilters(filter).build();
+    }
 
     @MockBean
     private BlobContainerClientProvider blobContainerClientProvider;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/SasTokenControllerTest.java
@@ -4,12 +4,16 @@ import com.azure.storage.common.Utility;
 import com.azure.storage.common.implementation.StorageImplUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProvider;
 
@@ -20,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -27,6 +32,16 @@ public class SasTokenControllerTest extends ControllerTestBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        WebRequestTrackingFilter filter = new WebRequestTrackingFilter();
+        filter.init(new MockFilterConfig());
+        mockMvc = webAppContextSetup(wac).addFilters(filter).build();
+    }
 
     @MockBean
     private BlobContainerClientProvider blobContainerClientProvider;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/features/SchedulerConfigTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/features/SchedulerConfigTest.java
@@ -48,7 +48,7 @@ public class SchedulerConfigTest {
 
     @Test
     public void should_integrate_with_shedlock() throws Exception {
-        ArgumentCaptor<LockConfiguration> configCaptor = ArgumentCaptor.forClass(LockConfiguration.class);
+        var configCaptor = ArgumentCaptor.forClass(LockConfiguration.class);
 
         // wait for asynchronous run of the scheduled task in background
         Thread.sleep(2000);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/features/SchedulerConfigTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/features/SchedulerConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.reform.blobrouter.tasks.DeleteDispatchedFilesTask;
 import uk.gov.hmcts.reform.blobrouter.tasks.HandleRejectedFilesTask;
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
         "scheduling.task.send-daily-report.cron: */1 * * * * *"
     }
 )
-@Profile("integration-test")
+@ActiveProfiles("integration-test")
 public class SchedulerConfigTest {
 
     @SpyBean

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -1,3 +1,5 @@
+azure.application-insights.instrumentation-key=integration-test
+
 storage.account-name=bulkscan
 storage.account-key=testkey
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/SchedulerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/SchedulerConfiguration.java
@@ -12,13 +12,12 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import static java.time.LocalDateTime.now;
+import static uk.gov.hmcts.reform.blobrouter.util.TimeZones.nowInLondon;
 
 @Configuration
 public class SchedulerConfiguration implements SchedulingConfigurer {
@@ -27,8 +26,7 @@ public class SchedulerConfiguration implements SchedulingConfigurer {
     private static AtomicInteger errorCount = new AtomicInteger(0);
     private static final Logger log = LoggerFactory.getLogger(SchedulerConfiguration.class);
 
-    private static final Supplier<Long> CURRENT_MILLIS_SUPPLIER = () -> now()
-        .atZone(ZoneId.of("Europe/London")).toInstant().toEpochMilli();
+    private static final Supplier<Long> CURRENT_MILLIS_SUPPLIER = () -> nowInLondon().toInstant().toEpochMilli();
 
     private static final Supplier<RequestTelemetryContext> REQUEST_CONTEXT_SUPPLIER = () ->
         new RequestTelemetryContext(CURRENT_MILLIS_SUPPLIER.get(), null);

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/logging/AppInsights.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.blobrouter.logging;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import static org.slf4j.LoggerFactory.getLogger;
+import static uk.gov.hmcts.reform.blobrouter.util.TimeZones.nowInLondon;
+
+@Aspect
+@Component
+public class AppInsights {
+
+    private static final Logger log = getLogger(AppInsights.class);
+
+    private final TelemetryClient telemetryClient;
+
+    public AppInsights(TelemetryClient telemetryClient) {
+        this.telemetryClient = telemetryClient;
+    }
+
+    // schedules
+
+    @Around("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    public void aroundSchedule(ProceedingJoinPoint joinPoint) throws Throwable {
+        RequestTelemetryContext requestTelemetry = ThreadContext.getRequestTelemetryContext();
+        boolean success = false;
+
+        try {
+            joinPoint.proceed();
+
+            success = true;
+        } finally {
+            handleRequestTelemetry(requestTelemetry, joinPoint.getTarget().getClass().getSimpleName(), success);
+        }
+    }
+
+    private void handleRequestTelemetry(
+        RequestTelemetryContext requestTelemetryContext,
+        String caller,
+        boolean success
+    ) {
+        String requestName = "Schedule /" + caller;
+
+        if (requestTelemetryContext != null) {
+            handleRequestTelemetry(
+                requestTelemetryContext.getHttpRequestTelemetry(),
+                requestName,
+                requestTelemetryContext.getRequestStartTimeTicks(),
+                success
+            );
+        } else {
+            log.warn(
+                "Request Telemetry Context has been removed by ThreadContext - cannot log '{}' request",
+                requestName
+            );
+        }
+    }
+
+    private void handleRequestTelemetry(
+        RequestTelemetry requestTelemetry,
+        String requestName,
+        long start,
+        boolean success
+    ) {
+        if (requestTelemetry != null) {
+            requestTelemetry.setName(requestName);
+            requestTelemetry.setDuration(new Duration(
+                nowInLondon().toInstant().toEpochMilli() - start
+            ));
+            requestTelemetry.setSuccess(success);
+
+            telemetryClient.trackRequest(requestTelemetry);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/TimeZones.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/TimeZones.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.blobrouter.util;
 
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static java.time.LocalDateTime.now;
 
 public final class TimeZones {
 
@@ -9,5 +12,9 @@ public final class TimeZones {
 
     private TimeZones() {
         // utility class construct
+    }
+
+    public static ZonedDateTime nowInLondon() {
+        return now().atZone(ZoneId.of(EUROPE_LONDON));
     }
 }


### PR DESCRIPTION
### Change description ###

Code was pending locally until #160 comes back to play. Now possible to add next level - top level tracking for e2e transaction feature provided by App Insights.

References:
- [microsoft guideline](https://github.com/microsoft/ApplicationInsights-Java/wiki/Distributed-Tracing-in-Asynchronous-Java-Applications#context-propagation-in-scheduled-events)
- [send letter service](https://github.com/hmcts/send-letter-service/blob/master/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java) introduced [some time ago](https://github.com/hmcts/send-letter-service/pull/437)
- web filter fix for app insights dependency in integration tests hmcts/send-letter-service#563

Note. 2 extra commits "fixing" up modified test file

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
