### PR TITLE
Clean up storage beans

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -24,10 +24,7 @@ public class StorageConfiguration {
     }
 
     // not used as needs test context so it can actually be build
-    @Bean({
-        "storage-client",
-        "bulkscan-storage-client"
-    })
+    @Bean()
     public BlobServiceClient getStorageClient(StorageSharedKeyCredential credentials) {
         return new BlobServiceClientBuilder().credential(credentials).buildClient();
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -29,7 +29,7 @@ public class StorageConfiguration {
         return blobClient -> new BlobLeaseClientBuilder().blobClient(blobClient).buildClient();
     }
 
-    @Bean("storage-client")
+    @Bean
     public BlobServiceClient getStorageClient(
         StorageSharedKeyCredential credentials,
         @Value("${storage.url}") String storageUrl

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -5,7 +5,6 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
@@ -51,7 +50,7 @@ public class BlobProcessor {
     private final Map<String, ServiceConfiguration.StorageConfig> storageConfig;
 
     public BlobProcessor(
-        @Qualifier("storage-client") BlobServiceClient storageClient,
+        BlobServiceClient storageClient,
         BlobDispatcher dispatcher,
         BlobReadinessChecker readinessChecker,
         EnvelopeRepository envelopeRepository,

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
@@ -6,7 +6,6 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobStorageException;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.Envelope;
@@ -23,7 +22,7 @@ public class ContainerCleaner {
     private final EnvelopeRepository envelopeRepository;
 
     public ContainerCleaner(
-        @Qualifier("storage-client") BlobServiceClient storageClient,
+        BlobServiceClient storageClient,
         EnvelopeRepository envelopeRepository
     ) {
         this.storageClient = storageClient;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -17,7 +17,7 @@ public class ContainerProcessor {
     private final BlobProcessor blobProcessor;
 
     public ContainerProcessor(
-        @Qualifier("storage-client") BlobServiceClient storageClient,
+        BlobServiceClient storageClient,
         BlobProcessor blobProcessor
     ) {
         this.storageClient = storageClient;


### PR DESCRIPTION
At some stage there were 2 beans of type `BlobServiceClient`. There's only one now. Removing qualifier