### PR TITLE
Extract StorageConfig out of ServiceConfiguration

### DIFF
--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -1,7 +1,7 @@
 storage.account-name=bulkscan
 storage.account-key=testkey
 
-service.storage-config[0].name=bulkscan
+service.storage-config[0].source-container=bulkscan
 service.storage-config[0].sas-validity=300
 service.storage-config[0].target-storage-account=bulkscan
 service.storage-config[0].target-container=bulkscan-target

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
@@ -10,16 +10,16 @@ import java.util.stream.Collectors;
 @ConfigurationProperties(prefix = "service")
 public class ServiceConfiguration {
 
-    private Map<String, StorageConfig> storageConfig;
+    private Map<String, StorageConfigItem> storageConfig;
 
-    public Map<String, StorageConfig> getStorageConfig() {
+    public Map<String, StorageConfigItem> getStorageConfig() {
         return storageConfig;
     }
 
-    public void setStorageConfig(List<StorageConfig> storageConfig) {
-        this.storageConfig = storageConfig
+    public void setStorageConfig(List<StorageConfigItem> storageConfigItems) {
+        this.storageConfig = storageConfigItems
             .stream()
-            .collect(Collectors.toMap(StorageConfig::getSourceContainer, Function.identity()));
+            .collect(Collectors.toMap(StorageConfigItem::getSourceContainer, Function.identity()));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
@@ -19,7 +19,7 @@ public class ServiceConfiguration {
     public void setStorageConfig(List<StorageConfig> storageConfig) {
         this.storageConfig = storageConfig
             .stream()
-            .collect(Collectors.toMap(StorageConfig::getName, Function.identity()));
+            .collect(Collectors.toMap(StorageConfig::getSourceContainer, Function.identity()));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ServiceConfiguration.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.validation.constraints.NotNull;
 
 @ConfigurationProperties(prefix = "service")
 public class ServiceConfiguration {
@@ -23,56 +22,4 @@ public class ServiceConfiguration {
             .collect(Collectors.toMap(StorageConfig::getName, Function.identity()));
     }
 
-    public static class StorageConfig {
-        private String name;
-        private int sasValidity;
-
-        @NotNull
-        private TargetStorageAccount targetStorageAccount;
-
-        @NotNull
-        private String targetContainer;
-
-        private boolean isEnabled = true;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public int getSasValidity() {
-            return sasValidity;
-        }
-
-        public void setSasValidity(int sasValidity) {
-            this.sasValidity = sasValidity;
-        }
-
-        public boolean isEnabled() {
-            return isEnabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            isEnabled = enabled;
-        }
-
-        public TargetStorageAccount getTargetStorageAccount() {
-            return targetStorageAccount;
-        }
-
-        public void setTargetStorageAccount(TargetStorageAccount targetStorageAccount) {
-            this.targetStorageAccount = targetStorageAccount;
-        }
-
-        public String getTargetContainer() {
-            return targetContainer;
-        }
-
-        public void setTargetContainer(String targetContainer) {
-            this.targetContainer = targetContainer;
-        }
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfig.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.blobrouter.config;
+
+import javax.validation.constraints.NotNull;
+
+public class StorageConfig {
+    private String name;
+    private int sasValidity;
+
+    @NotNull
+    private TargetStorageAccount targetStorageAccount;
+
+    @NotNull
+    private String targetContainer;
+
+    private boolean isEnabled = true;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getSasValidity() {
+        return sasValidity;
+    }
+
+    public void setSasValidity(int sasValidity) {
+        this.sasValidity = sasValidity;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    public TargetStorageAccount getTargetStorageAccount() {
+        return targetStorageAccount;
+    }
+
+    public void setTargetStorageAccount(TargetStorageAccount targetStorageAccount) {
+        this.targetStorageAccount = targetStorageAccount;
+    }
+
+    public String getTargetContainer() {
+        return targetContainer;
+    }
+
+    public void setTargetContainer(String targetContainer) {
+        this.targetContainer = targetContainer;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfig.java
@@ -3,24 +3,19 @@ package uk.gov.hmcts.reform.blobrouter.config;
 import javax.validation.constraints.NotNull;
 
 public class StorageConfig {
-    private String name;
+
     private int sasValidity;
 
     @NotNull
     private TargetStorageAccount targetStorageAccount;
 
     @NotNull
+    private String sourceContainer;
+
+    @NotNull
     private String targetContainer;
 
     private boolean isEnabled = true;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 
     public int getSasValidity() {
         return sasValidity;
@@ -44,6 +39,14 @@ public class StorageConfig {
 
     public void setTargetStorageAccount(TargetStorageAccount targetStorageAccount) {
         this.targetStorageAccount = targetStorageAccount;
+    }
+
+    public String getSourceContainer() {
+        return sourceContainer;
+    }
+
+    public void setSourceContainer(String sourceContainer) {
+        this.sourceContainer = sourceContainer;
     }
 
     public String getTargetContainer() {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfigItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfigItem.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.blobrouter.config;
 
 import javax.validation.constraints.NotNull;
 
-public class StorageConfig {
+public class StorageConfigItem {
 
     private int sasValidity;
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceDisabledException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceDisabledException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
@@ -45,7 +45,7 @@ public class SasTokenGeneratorService {
     }
 
     private BlobServiceSasSignatureValues getBlobServiceSasSignatureValues(String serviceName) {
-        StorageConfig config = getConfigForService(serviceName);
+        StorageConfigItem config = getConfigForService(serviceName);
 
         var permissions = new BlobContainerSasPermission()
             .setListPermission(true)
@@ -58,8 +58,8 @@ public class SasTokenGeneratorService {
             .setPermissions(permissions);
     }
 
-    private StorageConfig getConfigForService(String serviceName) {
-        StorageConfig config = serviceConfiguration.getStorageConfig().get(serviceName);
+    private StorageConfigItem getConfigForService(String serviceName) {
+        StorageConfigItem config = serviceConfiguration.getStorageConfig().get(serviceName);
         if (config == null) {
             throw new ServiceConfigNotFoundException("No service configuration found for " + serviceName);
         } else if (!config.isEnabled()) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerProcessor;
 
 import java.util.Collections;
@@ -49,8 +50,8 @@ public class BlobDispatcherTask {
         return serviceConfiguration.getStorageConfig()
             .values()
             .stream()
-            .filter(ServiceConfiguration.StorageConfig::isEnabled)
-            .map(ServiceConfiguration.StorageConfig::getName)
+            .filter(StorageConfig::isEnabled)
+            .map(StorageConfig::getName)
             .collect(toList());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
@@ -51,7 +51,7 @@ public class BlobDispatcherTask {
             .values()
             .stream()
             .filter(StorageConfig::isEnabled)
-            .map(StorageConfig::getName)
+            .map(StorageConfig::getSourceContainer)
             .collect(toList());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTask.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerProcessor;
 
 import java.util.Collections;
@@ -50,8 +50,8 @@ public class BlobDispatcherTask {
         return serviceConfiguration.getStorageConfig()
             .values()
             .stream()
-            .filter(StorageConfig::isEnabled)
-            .map(StorageConfig::getSourceContainer)
+            .filter(StorageConfigItem::isEnabled)
+            .map(StorageConfigItem::getSourceContainer)
             .collect(toList());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
@@ -50,7 +50,7 @@ public class DeleteDispatchedFilesTask {
             .values()
             .stream()
             .filter(StorageConfig::isEnabled)
-            .map(StorageConfig::getName);
+            .map(StorageConfig::getSourceContainer);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerCleaner;
 
 import java.util.stream.Stream;
@@ -48,8 +49,8 @@ public class DeleteDispatchedFilesTask {
         return serviceConfiguration.getStorageConfig()
             .values()
             .stream()
-            .filter(ServiceConfiguration.StorageConfig::isEnabled)
-            .map(ServiceConfiguration.StorageConfig::getName);
+            .filter(StorageConfig::isEnabled)
+            .map(StorageConfig::getName);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTask.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerCleaner;
 
 import java.util.stream.Stream;
@@ -49,8 +49,8 @@ public class DeleteDispatchedFilesTask {
         return serviceConfiguration.getStorageConfig()
             .values()
             .stream()
-            .filter(StorageConfig::isEnabled)
-            .map(StorageConfig::getSourceContainer);
+            .filter(StorageConfigItem::isEnabled)
+            .map(StorageConfigItem::getSourceContainer);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
@@ -49,7 +49,7 @@ public class BlobProcessor {
     private final BlobSignatureVerifier signatureVerifier;
 
     // container-specific configuration, by container name
-    private final Map<String, StorageConfig> storageConfig;
+    private final Map<String, StorageConfigItem> storageConfig;
 
     public BlobProcessor(
         @Qualifier("storage-client") BlobServiceClient storageClient,
@@ -106,7 +106,7 @@ public class BlobProcessor {
                 boolean validSignature = signatureVerifier.verifyZipSignature(blobName, rawBlob);
 
                 if (validSignature) {
-                    StorageConfig containerConfig = storageConfig.get(containerName);
+                    StorageConfigItem containerConfig = storageConfig.get(containerName);
                     TargetStorageAccount targetStorageAccount = containerConfig.getTargetStorageAccount();
                     var targetContainerName = containerConfig.getTargetContainer();
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
@@ -48,7 +49,7 @@ public class BlobProcessor {
     private final BlobSignatureVerifier signatureVerifier;
 
     // container-specific configuration, by container name
-    private final Map<String, ServiceConfiguration.StorageConfig> storageConfig;
+    private final Map<String, StorageConfig> storageConfig;
 
     public BlobProcessor(
         @Qualifier("storage-client") BlobServiceClient storageClient,
@@ -105,7 +106,7 @@ public class BlobProcessor {
                 boolean validSignature = signatureVerifier.verifyZipSignature(blobName, rawBlob);
 
                 if (validSignature) {
-                    ServiceConfiguration.StorageConfig containerConfig = storageConfig.get(containerName);
+                    StorageConfig containerConfig = storageConfig.get(containerName);
                     TargetStorageAccount targetStorageAccount = containerConfig.getTargetStorageAccount();
                     var targetContainerName = containerConfig.getTargetContainer();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,32 +21,32 @@ spring:
 
 service:
   storage-config:
-    - name: bulkscan
+    - source-container: bulkscan
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: bulkscan
-    - name: cmc
+    - source-container: cmc
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: cmc
-    - name: crime
+    - source-container: crime
       sas-validity: 300 #In seconds
       enabled: ${CRIME_ENABLED:false}
       target-storage-account: crime
       target-container: ${CRIME_DESTINATION_CONTAINER}
-    - name: divorce
+    - source-container: divorce
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: divorce
-    - name: finrem
+    - source-container: finrem
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: finrem
-    - name: probate
+    - source-container: probate
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: probate
-    - name: sscs
+    - source-container: sscs
       sas-validity: 300 #In seconds
       target-storage-account: bulkscan
       target-container: sscs

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
@@ -6,7 +6,7 @@ import com.azure.storage.common.implementation.StorageImplUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceDisabledException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
@@ -83,8 +83,8 @@ class SasTokenGeneratorServiceTest {
             .hasMessage("Unable to generate SAS token for service " + VALID_SERVICE);
     }
 
-    private static StorageConfig cfg(String name, int validity, boolean enabled) {
-        StorageConfig config = new StorageConfig();
+    private static StorageConfigItem cfg(String name, int validity, boolean enabled) {
+        StorageConfigItem config = new StorageConfigItem();
         config.setSasValidity(validity);
         config.setSourceContainer(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
@@ -86,7 +86,7 @@ class SasTokenGeneratorServiceTest {
     private static StorageConfig cfg(String name, int validity, boolean enabled) {
         StorageConfig config = new StorageConfig();
         config.setSasValidity(validity);
-        config.setName(name);
+        config.setSourceContainer(name);
         config.setEnabled(enabled);
         return config;
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorServiceTest.java
@@ -6,6 +6,7 @@ import com.azure.storage.common.implementation.StorageImplUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceDisabledException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
@@ -82,8 +83,8 @@ class SasTokenGeneratorServiceTest {
             .hasMessage("Unable to generate SAS token for service " + VALID_SERVICE);
     }
 
-    private static ServiceConfiguration.StorageConfig cfg(String name, int validity, boolean enabled) {
-        ServiceConfiguration.StorageConfig config = new ServiceConfiguration.StorageConfig();
+    private static StorageConfig cfg(String name, int validity, boolean enabled) {
+        StorageConfig config = new StorageConfig();
         config.setSasValidity(validity);
         config.setName(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerProcessor;
 
 import static java.util.Arrays.asList;
@@ -67,8 +67,8 @@ class BlobDispatcherTaskTest {
         verify(containerProcessor, never()).process(any()); // no available containers
     }
 
-    private StorageConfig configure(String name, boolean enabled) {
-        StorageConfig config = new StorageConfig();
+    private StorageConfigItem configure(String name, boolean enabled) {
+        StorageConfigItem config = new StorageConfigItem();
         config.setSasValidity(300);
         config.setSourceContainer(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerProcessor;
 
 import static java.util.Arrays.asList;
@@ -66,8 +67,8 @@ class BlobDispatcherTaskTest {
         verify(containerProcessor, never()).process(any()); // no available containers
     }
 
-    private ServiceConfiguration.StorageConfig configure(String name, boolean enabled) {
-        ServiceConfiguration.StorageConfig config = new ServiceConfiguration.StorageConfig();
+    private StorageConfig configure(String name, boolean enabled) {
+        StorageConfig config = new StorageConfig();
         config.setSasValidity(300);
         config.setName(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/BlobDispatcherTaskTest.java
@@ -70,7 +70,7 @@ class BlobDispatcherTaskTest {
     private StorageConfig configure(String name, boolean enabled) {
         StorageConfig config = new StorageConfig();
         config.setSasValidity(300);
-        config.setName(name);
+        config.setSourceContainer(name);
         config.setEnabled(enabled);
         return config;
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
@@ -69,7 +69,7 @@ class DeleteDispatchedFilesTaskTest {
     private StorageConfig configure(String name, boolean enabled) {
         StorageConfig config = new StorageConfig();
         config.setSasValidity(300);
-        config.setName(name);
+        config.setSourceContainer(name);
         config.setEnabled(enabled);
         return config;
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerCleaner;
 
 import static java.util.Arrays.asList;
@@ -65,8 +66,8 @@ class DeleteDispatchedFilesTaskTest {
         verifyNoInteractions(containerCleaner); // no available containers
     }
 
-    private ServiceConfiguration.StorageConfig configure(String name, boolean enabled) {
-        ServiceConfiguration.StorageConfig config = new ServiceConfiguration.StorageConfig();
+    private StorageConfig configure(String name, boolean enabled) {
+        StorageConfig config = new StorageConfig();
         config.setSasValidity(300);
         config.setName(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/DeleteDispatchedFilesTaskTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.tasks.processors.ContainerCleaner;
 
 import static java.util.Arrays.asList;
@@ -66,8 +66,8 @@ class DeleteDispatchedFilesTaskTest {
         verifyNoInteractions(containerCleaner); // no available containers
     }
 
-    private StorageConfig configure(String name, boolean enabled) {
-        StorageConfig config = new StorageConfig();
+    private StorageConfigItem configure(String name, boolean enabled) {
+        StorageConfigItem config = new StorageConfigItem();
         config.setSasValidity(300);
         config.setSourceContainer(name);
         config.setEnabled(enabled);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -11,7 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
-import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
@@ -313,7 +313,7 @@ class BlobProcessorTest {
         String targetContainer,
         TargetStorageAccount targetStorageAccount
     ) {
-        var containerConfig = new StorageConfig();
+        var containerConfig = new StorageConfigItem();
         containerConfig.setEnabled(true);
         containerConfig.setSourceContainer(sourceContainer);
         containerConfig.setTargetContainer(targetContainer);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -315,7 +315,7 @@ class BlobProcessorTest {
     ) {
         var containerConfig = new StorageConfig();
         containerConfig.setEnabled(true);
-        containerConfig.setName(sourceContainer);
+        containerConfig.setSourceContainer(sourceContainer);
         containerConfig.setTargetContainer(targetContainer);
         containerConfig.setTargetStorageAccount(targetStorageAccount);
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
+import uk.gov.hmcts.reform.blobrouter.config.StorageConfig;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
@@ -312,7 +313,7 @@ class BlobProcessorTest {
         String targetContainer,
         TargetStorageAccount targetStorageAccount
     ) {
-        var containerConfig = new ServiceConfiguration.StorageConfig();
+        var containerConfig = new StorageConfig();
         containerConfig.setEnabled(true);
         containerConfig.setName(sourceContainer);
         containerConfig.setTargetContainer(targetContainer);


### PR DESCRIPTION
### Change description ###

Make StorageConfig a top-level class and not an internal class of ServiceConfiguration. The reason is that this storage config is used by some application classes. Also, rename this class to StorageConfigItem, because:
- by convention, our classed with Config/Configuration suffix Spring configuration classes
- a class called StorageConfiguration already exists and there would be a confusion between the two

Also, renamed the `name` property in the related config item to `source-container`, because that's what this name represents. Recently, `target-container` field was added.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
