### PR TITLE
Revert notification change

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.24
+version: 0.0.23
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.23
+version: 0.0.25
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/requirements.yaml
+++ b/charts/reform-scan-blob-router/requirements.yaml
@@ -17,7 +17,3 @@ dependencies:
     version: ~0.2.1
     repository: '@hmctspublic'
     condition: crimeblobstorage.enabled
-  - name: servicebus
-    version: ~0.2.2
-    repository: '@hmctspublic'
-    condition: servicebus.enabled

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -15,9 +15,6 @@ java:
     STORAGE_CRIME_ACCOUNT_KEY:
       secretRef: storage-secret-crime-{{ .Release.Name }}
       key: accessKey
-    SB_CONN_STRING:
-      secretRef: servicebus-secret-namespace-{{ .Release.Name }}
-      key: connectionString
   keyVaults:
     reform-scan:
       resourceGroup: reform-scan
@@ -45,8 +42,6 @@ java:
 
     STORAGE_URL: "https://$(STORAGE_ACCOUNT_NAME).blob.core.windows.net"
     STORAGE_CRIME_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_CRIME_ACCOUNT_NAME);AccountKey=$(STORAGE_CRIME_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
-
-    QUEUE_NOTIFICATION_SEND_CONN_STRING: "$(SB_CONN_STRING);EntityPath=notifications"
 
     BULK_SCAN_PROCESSOR_URL: http://bulk-scan-processor-aat.service.core-compute-aat.internal
     CRIME_DESTINATION_CONTAINER: bs-sit-scans-received
@@ -88,13 +83,3 @@ crimeblobstorage:
   setup:
     containers:
       - bs-sit-scans-received
-
-servicebus:
-  resourceGroup: reform-scan-aks
-  teamName: "BSP"
-  location: ukwest
-  serviceplan: basic
-  setup:
-    queues:
-      - name: notifications
-  enabled: true

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -16,7 +16,6 @@ java:
         - crime-storage-connection-string
         - flyway-password
         - blob-router-POSTGRES-PASS
-        - notifications-queue-send-connection-string
   environment:
     DB_HOST: reform-scan-blob-router-{{ .Values.global.environment }}.postgres.database.azure.com
     DB_PORT: '5432'
@@ -45,6 +44,4 @@ reformblobstorage:
 cftblobstorage:
   enabled: false
 crimeblobstorage:
-  enabled: false
-servicebus:
   enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,7 +68,3 @@ scheduling:
       cron: ${HANDLE_REJECTED_FILES_CRON}
     scan:
       delay: ${TASK_SCAN_DELAY} # In milliseconds
-
-queue:
-  notification:
-    queue-name: notifications

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -16,4 +16,3 @@ spring:
         crime-storage-connection-string: storage.crime.connection-string
         flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD
-        notifications-queue-send-connection-string: queue-notification-send-conn-string


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1008

### Change description ###

processor needs event id to  handle notifications so inserting messages to processor queue would not solve the problem easily. We decide not to send notification until new notification micro service gets ready.

reverting conf changes: https://github.com/hmcts/blob-router-service/pull/217

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
