### PR TITLE
Clean up zip verification

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.services.BlobSignatureVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
 import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseClientProvider;
+import uk.gov.hmcts.reform.blobrouter.util.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -35,9 +36,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class BlobProcessor {
 
     private static final Logger logger = getLogger(BlobProcessor.class);
-
-    // name of the zip entry (in a blob) that contains the envelope
-    private static final String ENVELOPE_ENTRY_NAME = "envelope.zip";
 
     private final BlobServiceClient storageClient;
     private final BlobDispatcher dispatcher;
@@ -163,13 +161,13 @@ public class BlobProcessor {
             ZipEntry entry = null;
 
             while ((entry = zipStream.getNextEntry()) != null) {
-                if (ENVELOPE_ENTRY_NAME.equals(entry.getName())) {
+                if (ZipVerifiers.DOCUMENTS_ZIP.equals(entry.getName())) {
                     return toByteArray(zipStream);
                 }
             }
 
             throw new InvalidZipArchiveException(
-                String.format("ZIP file doesn't contain the required %s entry", ENVELOPE_ENTRY_NAME)
+                String.format("ZIP file doesn't contain the required %s entry", ZipVerifiers.DOCUMENTS_ZIP)
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiers.java
@@ -94,7 +94,7 @@ public class ZipVerifiers {
 
     static void verifyFileNames(Set<String> fileNames) {
         if (!(fileNames.size() == 2 && fileNames.containsAll(asList(DOCUMENTS_ZIP, SIGNATURE_SIG)))) {
-            throw new DocSignatureFailureException(
+            throw new InvalidZipArchiveException(
                 "Zip entries do not match expected file names. Actual names = " + fileNames
             );
         }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.exceptions.DocSignatureFailureException;
+import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.SignatureValidationException;
 
 import java.io.ByteArrayInputStream;
@@ -101,7 +102,7 @@ class ZipVerifiersTest {
         );
 
         assertThatThrownBy(() -> ZipVerifiers.verifyFileNames(files))
-            .isInstanceOf(DocSignatureFailureException.class)
+            .isInstanceOf(InvalidZipArchiveException.class)
             .hasMessageContaining(INVALID_ZIP_ENTRIES_MESSAGE);
     }
 
@@ -113,7 +114,7 @@ class ZipVerifiersTest {
         );
 
         assertThatThrownBy(() -> ZipVerifiers.verifyFileNames(files))
-            .isInstanceOf(DocSignatureFailureException.class)
+            .isInstanceOf(InvalidZipArchiveException.class)
             .hasMessageContaining(INVALID_ZIP_ENTRIES_MESSAGE);
     }
 


### PR DESCRIPTION
- throw more appropriate exception when the content of zip file is invalid
- use already existing constant for zip file name in processor