### PR TITLE
Rename zip verification method

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
@@ -30,7 +30,7 @@ public class BlobSignatureVerifier {
         try (var zis = new ZipInputStream(new ByteArrayInputStream(rawBlob))) {
             var zipWithSignature = ZipVerifiers.ZipStreamWithSignature.fromKeyfile(zis, publicKeyDerFilename);
 
-            ZipVerifiers.verifyZipSignature(zipWithSignature);
+            ZipVerifiers.verifyZip(zipWithSignature);
             return true;
         } catch (DocSignatureFailureException ex) {
             logger.info("Invalid signature. Blob name: {}", blobName, ex);

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiers.java
@@ -68,12 +68,15 @@ public class ZipVerifiers {
     private ZipVerifiers() {
     }
 
-    public static ZipInputStream verifyZipSignature(ZipStreamWithSignature zipWithSignature)
-        throws DocSignatureFailureException {
+    public static ZipInputStream verifyZip(ZipStreamWithSignature zipWithSignature) {
         Map<String, byte[]> zipEntries = extractZipEntries(zipWithSignature.zipInputStream);
 
         verifyFileNames(zipEntries.keySet());
-        verifySignature(zipWithSignature.publicKeyBase64, zipEntries);
+        verifySignature(
+            zipWithSignature.publicKeyBase64,
+            zipEntries.get(DOCUMENTS_ZIP),
+            zipEntries.get(SIGNATURE_SIG)
+        );
 
         return new ZipInputStream(new ByteArrayInputStream(zipEntries.get(DOCUMENTS_ZIP)));
     }
@@ -98,14 +101,6 @@ public class ZipVerifiers {
                 "Zip entries do not match expected file names. Actual names = " + fileNames
             );
         }
-    }
-
-    private static void verifySignature(String publicKeyBase64, Map<String, byte[]> entries) {
-        verifySignature(
-            publicKeyBase64,
-            entries.get(DOCUMENTS_ZIP),
-            entries.get(SIGNATURE_SIG)
-        );
     }
 
     public static void verifySignature(String publicKeyBase64, byte[] data, byte[] signed) {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -125,7 +125,7 @@ class ZipVerifiersTest {
         var zipStreamWithSig = new ZipVerifiers.ZipStreamWithSignature(
             new ZipInputStream(new ByteArrayInputStream(zipBytes)), publicKeyBase64
         );
-        ZipInputStream zis = ZipVerifiers.verifyZipSignature(zipStreamWithSig);
+        ZipInputStream zis = ZipVerifiers.verifyZip(zipStreamWithSig);
         assertThat(zis).isNotNull();
     }
 
@@ -138,7 +138,7 @@ class ZipVerifiersTest {
         );
         assertThrows(
             DocSignatureFailureException.class,
-            () -> ZipVerifiers.verifyZipSignature(zipStreamWithSig)
+            () -> ZipVerifiers.verifyZip(zipStreamWithSig)
         );
     }
 


### PR DESCRIPTION
Method `verifyZipSignature` does not only verify the signature, but also that the file is a an actual zip archive (and throws an appropriate exception) and that the zip archive contains expected files.

Renaming for clarity.