### PR TITLE
Zip verification cleanup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.exceptions.DocSignatureFailureException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
-import uk.gov.hmcts.reform.blobrouter.util.ZipVerifiers;
+import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.services.BlobSignatureVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
 import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseClientProvider;
-import uk.gov.hmcts.reform.blobrouter.util.ZipVerifiers;
+import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -161,13 +161,13 @@ public class BlobProcessor {
             ZipEntry entry = null;
 
             while ((entry = zipStream.getNextEntry()) != null) {
-                if (ZipVerifiers.DOCUMENTS_ZIP.equals(entry.getName())) {
+                if (ZipVerifiers.ENVELOPE.equals(entry.getName())) {
                     return toByteArray(zipStream);
                 }
             }
 
             throw new InvalidZipArchiveException(
-                String.format("ZIP file doesn't contain the required %s entry", ZipVerifiers.DOCUMENTS_ZIP)
+                String.format("ZIP file doesn't contain the required %s entry", ZipVerifiers.ENVELOPE)
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/README.md
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/README.md
@@ -1,0 +1,24 @@
+Some openssl commands related to sha256withrsa signatures:
+- Create rsa private key:
+
+        openssl genrsa -out private_key.pem 1024
+
+- Generate DER format private key from PEM:
+
+        openssl pkcs8 -topk8 -inform PEM -outform DER -in private_key.pem -out private_key.der -nocrypt
+
+- Generate DER format public key from PEM private key:
+
+        openssl rsa -in private_key.pem -pubout -outform DER -out public_key.der
+
+- Generate DER format public key from PEM public key:
+
+        openssl rsa -pubin -inform PEM -outform DER -in public_key.pem
+
+- Generate signature for file:
+
+        openssl dgst -sha256 -sign private_key.pem -out signature envelope.zip
+
+- Verify file signature:
+
+        openssl dgst -sha256 -verify public_key.pem -signature signature envelope.zip

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/ZipVerifiers.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.blobrouter.util;
+package uk.gov.hmcts.reform.blobrouter.util.zipverification;
 
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.reform.blobrouter.exceptions.DocSignatureFailureException;
@@ -27,42 +27,11 @@ import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
 import static java.util.Arrays.asList;
 
-/**
- * Signed zip archive verification utilities.
- * Currently verifies with sha256withrsa algorithm:
- * sha256withrsa = sha256 + rsa signature verification.
- * A signed zip archive must include 2 files named envelope.zip and signature.
- * The former is the archive content while the latter is the signature the
- * archive has to be verified against.
- * <p>
- * Some openssl commands related to sha256withrsa signatures:
- * <ul>
- * <li>Create rsa private key:
- * openssl genrsa -out private_key.pem 1024
- * </li>
- * <li>Generate DER format private key from PEM:
- * openssl pkcs8 -topk8 -inform PEM -outform DER -in private_key.pem
- * -out private_key.der -nocrypt
- * </li>
- * <li>Generate DER format public key from PEM private key:
- * openssl rsa -in private_key.pem -pubout -outform DER -out public_key.der
- * </li>
- * <li>Generate DER format public key from PEM public key:
- * openssl rsa -pubin -inform PEM -outform DER -in public_key.pem
- * </li>
- * <li>Generate signature for file:
- * openssl dgst -sha256 -sign private_key.pem -out signature envelope.zip
- * </li>
- * <li>Verify file signature:
- * openssl dgst -sha256 -verify public_key.pem -signature signature envelope.zip
- * </li>
- * </ul>
- * </p>
- */
 public class ZipVerifiers {
 
-    public static final String DOCUMENTS_ZIP = "envelope.zip";
-    public static final String SIGNATURE_SIG = "signature";
+    public static final String ENVELOPE = "envelope.zip";
+    public static final String SIGNATURE = "signature";
+
     public static final String INVALID_SIGNATURE_MESSAGE = "Zip signature failed verification";
 
     private ZipVerifiers() {
@@ -74,11 +43,11 @@ public class ZipVerifiers {
         verifyFileNames(zipEntries.keySet());
         verifySignature(
             zipWithSignature.publicKeyBase64,
-            zipEntries.get(DOCUMENTS_ZIP),
-            zipEntries.get(SIGNATURE_SIG)
+            zipEntries.get(ENVELOPE),
+            zipEntries.get(SIGNATURE)
         );
 
-        return new ZipInputStream(new ByteArrayInputStream(zipEntries.get(DOCUMENTS_ZIP)));
+        return new ZipInputStream(new ByteArrayInputStream(zipEntries.get(ENVELOPE)));
     }
 
     private static Map<String, byte[]> extractZipEntries(ZipInputStream zis) {
@@ -96,7 +65,7 @@ public class ZipVerifiers {
     }
 
     static void verifyFileNames(Set<String> fileNames) {
-        if (!(fileNames.size() == 2 && fileNames.containsAll(asList(DOCUMENTS_ZIP, SIGNATURE_SIG)))) {
+        if (!(fileNames.size() == 2 && fileNames.containsAll(asList(ENVELOPE, SIGNATURE)))) {
             throw new InvalidZipArchiveException(
                 "Zip entries do not match expected file names. Actual names = " + fileNames
             );

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/ZipVerifiers.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/zipverification/ZipVerifiers.java
@@ -64,7 +64,7 @@ public class ZipVerifiers {
         }
     }
 
-    static void verifyFileNames(Set<String> fileNames) {
+    public static void verifyFileNames(Set<String> fileNames) {
         if (!(fileNames.size() == 2 && fileNames.containsAll(asList(ENVELOPE, SIGNATURE)))) {
             throw new InvalidZipArchiveException(
                 "Zip entries do not match expected file names. Actual names = " + fileNames

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/DirectoryZipper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/DirectoryZipper.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.util;
 
 import com.google.common.io.Files;
+import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,8 +41,8 @@ public final class DirectoryZipper {
 
         return zipItems(
             asList(
-                new ZipItem(ZipVerifiers.DOCUMENTS_ZIP, innerZip),
-                new ZipItem(ZipVerifiers.SIGNATURE_SIG, signature)
+                new ZipItem(ZipVerifiers.ENVELOPE, innerZip),
+                new ZipItem(ZipVerifiers.SIGNATURE, signature)
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.exceptions.DocSignatureFailureException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.SignatureValidationException;
+import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -86,8 +87,8 @@ class ZipVerifiersTest {
     @Test
     void should_verify_2_valid_filenames_successfully() {
         Set<String> files = Set.of(
-            ZipVerifiers.DOCUMENTS_ZIP,
-            ZipVerifiers.SIGNATURE_SIG
+            ZipVerifiers.ENVELOPE,
+            ZipVerifiers.SIGNATURE
         );
 
         assertThatCode(() -> ZipVerifiers.verifyFileNames(files)).doesNotThrowAnyException();
@@ -96,8 +97,8 @@ class ZipVerifiersTest {
     @Test
     void should_not_verify_more_than_2_files_successfully() {
         Set<String> files = Set.of(
-            ZipVerifiers.DOCUMENTS_ZIP,
-            ZipVerifiers.SIGNATURE_SIG,
+            ZipVerifiers.ENVELOPE,
+            ZipVerifiers.SIGNATURE,
             "signature2"
         );
 
@@ -109,7 +110,7 @@ class ZipVerifiersTest {
     @Test
     void should_not_verify_invalid_filenames_successfully() {
         Set<String> files = Set.of(
-            ZipVerifiers.DOCUMENTS_ZIP,
+            ZipVerifiers.ENVELOPE,
             "signature.sig"
         );
 


### PR DESCRIPTION
Some cleanup:
- extract javadoc notes on how to generate/validate signatures to a markdown file
- rename constants for entries in the zip file