### PR TITLE
Separate test utils from tests for utils

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.blobrouter.data.model.Status.DISPATCHED;
-import static uk.gov.hmcts.reform.blobrouter.util.DirectoryZipper.zipAndSignDir;
+import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipAndSignDir;
 
 @ActiveProfiles("db-test")
 @SpringBootTest

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/DirectoryZipper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/DirectoryZipper.java
@@ -1,6 +1,7 @@
-package uk.gov.hmcts.reform.blobrouter.util;
+package uk.gov.hmcts.reform.blobrouter.testutils;
 
 import com.google.common.io.Files;
+import uk.gov.hmcts.reform.blobrouter.util.ZipVerifiers;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -14,14 +15,14 @@ import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static uk.gov.hmcts.reform.blobrouter.util.SigningHelper.signWithSha256Rsa;
+import static uk.gov.hmcts.reform.blobrouter.testutils.SigningHelper.signWithSha256Rsa;
 
 public final class DirectoryZipper {
 
     /**
      * Zips files from given directory. Files in resulting archive are NOT wrapped in a directory.
      */
-    static byte[] zipDir(String dirName) throws IOException {
+    public static byte[] zipDir(String dirName) throws IOException {
 
         return zipItems(
             Stream.of(new File(getResource(dirName).getPath()).listFiles())

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/ResourceFilesHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/ResourceFilesHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.blobrouter.util;
+package uk.gov.hmcts.reform.blobrouter.testutils;
 
 import org.junit.jupiter.api.Assertions;
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/SigningHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/SigningHelper.java
@@ -4,7 +4,7 @@ import java.security.KeyFactory;
 import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
 
-final class SigningHelper {
+public final class SigningHelper {
 
     public static byte[] signWithSha256Rsa(byte[] input, byte[] keyBytes) throws Exception {
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/SigningHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/testutils/SigningHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.blobrouter.util;
+package uk.gov.hmcts.reform.blobrouter.testutils;
 
 import java.security.KeyFactory;
 import java.security.Signature;
@@ -6,7 +6,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 
 final class SigningHelper {
 
-    static byte[] signWithSha256Rsa(byte[] input, byte[] keyBytes) throws Exception {
+    public static byte[] signWithSha256Rsa(byte[] input, byte[] keyBytes) throws Exception {
 
         Signature signature = Signature.getInstance("SHA256withRSA");
         signature.initSign(KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(keyBytes)));

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/BlobSignatureVerifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/BlobSignatureVerifierTest.java
@@ -7,8 +7,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.services.BlobSignatureVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.reform.blobrouter.util.DirectoryZipper.zipAndSignDir;
-import static uk.gov.hmcts.reform.blobrouter.util.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipAndSignDir;
+import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipDir;
 
 @ExtendWith(MockitoExtension.class)
 class BlobSignatureVerifierTest {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -22,9 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.hmcts.reform.blobrouter.util.DirectoryZipper.zipAndSignDir;
-import static uk.gov.hmcts.reform.blobrouter.util.DirectoryZipper.zipDir;
-import static uk.gov.hmcts.reform.blobrouter.util.SigningHelper.signWithSha256Rsa;
+import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipAndSignDir;
+import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipDir;
+import static uk.gov.hmcts.reform.blobrouter.testutils.SigningHelper.signWithSha256Rsa;
 
 @ExtendWith(MockitoExtension.class)
 class ZipVerifiersTest {


### PR DESCRIPTION
Currently `util` directory in tests contains both tests for classes that live in the `util` package in the main application as well as helper classes created just for the purpose of simplifying tests.

Splitting.