### PR TITLE
Remove redundant dependency management for tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,10 +164,6 @@ dependencyManagement {
     dependencySet(group: 'com.google.guava', version: '28.2-jre') {
       entry 'guava'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-websocket'
-    }
     dependencySet(group: 'org.testcontainers', version: '1.12.4') {
       entry 'database-commons' // not tagged to latest. once sorted - remove this section
     }


### PR DESCRIPTION
### Change description ###

Vulnerabilities already solved with latest spring boot updates. Management is redundant now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
