### PR TITLE
public key usage cleanup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.exceptions.DocSignatureFailureException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidConfigException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
+import uk.gov.hmcts.reform.blobrouter.util.PublicKeyDecoder;
 import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.PublicKey;
 import java.util.Base64;
 import java.util.zip.ZipInputStream;
 
@@ -22,13 +24,14 @@ public class BlobSignatureVerifier {
 
     private static final Logger logger = getLogger(BlobSignatureVerifier.class);
 
-    private final String publicKeyBase64;
+    private final PublicKey publicKey;
 
     public BlobSignatureVerifier(
         @Value("${public-key-der-file}") String publicKeyDerFilename
     ) {
         try {
-            publicKeyBase64 = Base64.getEncoder().encodeToString(toByteArray(getResource(publicKeyDerFilename)));
+            String publicKeyBase64 = Base64.getEncoder().encodeToString(toByteArray(getResource(publicKeyDerFilename)));
+            this.publicKey = PublicKeyDecoder.decode(publicKeyBase64);
         } catch (Exception e) {
             throw new InvalidConfigException("Error loading public key. File name: " + publicKeyDerFilename, e);
         }
@@ -37,7 +40,7 @@ public class BlobSignatureVerifier {
     public boolean verifyZipSignature(String blobName, byte[] rawBlob) {
         try (var zis = new ZipInputStream(new ByteArrayInputStream(rawBlob))) {
 
-            ZipVerifiers.verifyZip(zis, this.publicKeyBase64);
+            ZipVerifiers.verifyZip(zis, publicKey);
             return true;
         } catch (DocSignatureFailureException ex) {
             logger.info("Invalid signature. Blob name: {}", blobName, ex);

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
@@ -9,6 +9,10 @@ import java.util.Base64;
 
 public final class PublicKeyDecoder {
 
+    private PublicKeyDecoder() {
+        // util class
+    }
+
     public static PublicKey decode(String publicKeyBase64) throws NoSuchAlgorithmException, InvalidKeySpecException {
         return KeyFactory
             .getInstance("RSA")

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.blobrouter.util;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+public final class PublicKeyDecoder {
+
+    public static PublicKey decode(String publicKeyBase64) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return KeyFactory
+            .getInstance("RSA")
+            .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyBase64)));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/BlobSignatureVerifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/BlobSignatureVerifierTest.java
@@ -7,6 +7,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidConfigException;
 import uk.gov.hmcts.reform.blobrouter.services.BlobSignatureVerifier;
 
+import java.security.spec.InvalidKeySpecException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipAndSignDir;
@@ -65,5 +67,13 @@ class BlobSignatureVerifierTest {
             .isInstanceOf(InvalidConfigException.class)
             .hasMessageContaining("Error loading public key")
             .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_if_invalid_public_key_is_provided() {
+        assertThatThrownBy(() -> new BlobSignatureVerifier("signature/invalid_public_key_format.der"))
+            .isInstanceOf(InvalidConfigException.class)
+            .hasMessageContaining("Error loading public key")
+            .hasCauseInstanceOf(InvalidKeySpecException.class);
     }
 }


### PR DESCRIPTION
convert base64 encoded public key to a java object (`java.security.PublicKey`) in the service instead of separately for every zip file in the helper class.