### PR TITLE
Simplify loading public key

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobSignatureVerifier.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.PublicKey;
-import java.util.Base64;
 import java.util.zip.ZipInputStream;
 
 import static com.google.common.io.Resources.getResource;
@@ -30,8 +29,7 @@ public class BlobSignatureVerifier {
         @Value("${public-key-der-file}") String publicKeyDerFilename
     ) {
         try {
-            String publicKeyBase64 = Base64.getEncoder().encodeToString(toByteArray(getResource(publicKeyDerFilename)));
-            this.publicKey = PublicKeyDecoder.decode(publicKeyBase64);
+            this.publicKey = PublicKeyDecoder.decode(toByteArray(getResource(publicKeyDerFilename)));
         } catch (Exception e) {
             throw new InvalidConfigException("Error loading public key. File name: " + publicKeyDerFilename, e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/util/PublicKeyDecoder.java
@@ -5,7 +5,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 
 public final class PublicKeyDecoder {
 
@@ -13,9 +12,9 @@ public final class PublicKeyDecoder {
         // util class
     }
 
-    public static PublicKey decode(String publicKeyBase64) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public static PublicKey decode(byte[] publicKeyBytes) throws NoSuchAlgorithmException, InvalidKeySpecException {
         return KeyFactory
             .getInstance("RSA")
-            .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyBase64)));
+            .generatePublic(new X509EncodedKeySpec(publicKeyBytes));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/util/ZipVerifiersTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 import java.io.ByteArrayInputStream;
 import java.security.PublicKey;
 import java.security.SignatureException;
-import java.util.Base64;
 import java.util.Set;
 import java.util.zip.ZipInputStream;
 
@@ -200,10 +199,6 @@ class ZipVerifiersTest {
     }
 
     private static PublicKey loadPublicKey(String fileName) throws Exception {
-        return PublicKeyDecoder.decode(
-            Base64.getEncoder().encodeToString(
-                toByteArray(getResource(fileName))
-            )
-        );
+        return PublicKeyDecoder.decode(toByteArray(getResource(fileName)));
     }
 }


### PR DESCRIPTION
There's no need to encode it to base64 (much easier to spot after previous refactoring PR https://github.com/hmcts/blob-router-service/pull/247).