### PR TITLE
Add service method for saving 'duplicate envelope' event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/model/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/model/Event.java
@@ -4,4 +4,5 @@ public enum Event {
     FILE_PROCESSING_STARTED,
     DISPATCHED,
     REJECTED,
+    DUPLICATE_REJECTED
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.EventRecordRepository;
 import uk.gov.hmcts.reform.blobrouter.data.model.Envelope;
+import uk.gov.hmcts.reform.blobrouter.data.model.Event;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
+import uk.gov.hmcts.reform.blobrouter.data.model.NewEventRecord;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
 
 import java.time.Instant;
@@ -67,5 +69,10 @@ public class EnvelopeService {
     @Transactional
     public void markEnvelopeAsDeleted(UUID envelopeId) {
         envelopeRepository.markAsDeleted(envelopeId);
+    }
+
+    @Transactional
+    public void saveEventDuplicateRejected(String containerName, String blobName) {
+        eventRecordRepository.insert(new NewEventRecord(containerName, blobName, Event.DUPLICATE_REJECTED));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.data.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.EventRecordRepository;
+import uk.gov.hmcts.reform.blobrouter.data.model.Event;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEventRecord;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
@@ -103,5 +104,19 @@ class EnvelopeServiceTest {
         var newEventRecordCaptor = ArgumentCaptor.forClass(NewEventRecord.class);
         verify(eventRecordRepository, never()).insert(newEventRecordCaptor.capture());
         assertThat(newEventRecordCaptor.getAllValues()).isEmpty();
+    }
+
+    @Test
+    void should_record_process_start_event() {
+        // when
+        envelopeService.saveEventDuplicateRejected(CONTAINER_NAME, BLOB_NAME);
+
+        // then
+        var newEventRecordCaptor = ArgumentCaptor.forClass(NewEventRecord.class);
+        verify(eventRecordRepository).insert(newEventRecordCaptor.capture());
+        assertThat(newEventRecordCaptor.getValue().event).isEqualTo(Event.DUPLICATE_REJECTED);
+
+        // and
+        verifyNoInteractions(envelopeRepository);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -107,7 +107,7 @@ class EnvelopeServiceTest {
     }
 
     @Test
-    void should_record_process_start_event() {
+    void should_record_duplicate_rejected_event() {
         // when
         envelopeService.saveEventDuplicateRejected(CONTAINER_NAME, BLOB_NAME);
 


### PR DESCRIPTION
Following naming convention from https://github.com/hmcts/blob-router-service/pull/265