### PR TITLE
Build reform storage connection string

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.27
+version: 0.0.28
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -16,7 +16,6 @@ java:
         - crime-storage-connection-string
         - flyway-password
         - blob-router-POSTGRES-PASS
-        - storage-reform-connection-string
   environment:
     DB_HOST: reform-scan-blob-router-{{ .Values.global.environment }}.postgres.database.azure.com
     DB_PORT: '5432'
@@ -38,6 +37,8 @@ java:
     CRIME_DESTINATION_CONTAINER: bs-sit-scans-received
 
     BULK_SCAN_PROCESSOR_URL: http://bulk-scan-processor-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+
+    STORAGE_REFORM_CONNECTION_STRING: "DefaultEndpointsProtocol=https;BlobEndpoint=https://reformscan.{{ .Values.global.environment }}.platform.hmcts.net;AccountName=$(STORAGE_ACCOUNT_NAME);AccountKey=$(STORAGE_ACCOUNT_KEY)"
 
     SMTP_HOST: "false"
   image: 'hmctspublic.azurecr.io/reform-scan/blob-router:latest'

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -16,6 +16,5 @@ spring:
         crime-storage-connection-string: storage.crime.connection-string
         flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD
-        storage-reform-connection-string: storage.reform.connection-string
         reports-email-username: SMTP_USERNAME
         reports-email-password: SMTP_PASSWORD


### PR DESCRIPTION
### Change description ###

Build reform storage connection string, instead of retrieving it from Key Vault. Currently, setting that secret in Vault is a manual step.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
