### PR TITLE
Build connection string to reform scan storage in code

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.27
+version: 0.0.28
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -40,7 +40,7 @@ java:
 
     STORAGE_BULKSCAN_URL: https://bulkscanaat.blob.core.windows.net
 
-    STORAGE_REFORM_CONNECTION_STRING: "DefaultEndpointsProtocol=https;BlobEndpoint=https://$(STORAGE_ACCOUNT_NAME).blob.core.windows.net;AccountName=$(STORAGE_ACCOUNT_NAME);AccountKey=$(STORAGE_ACCOUNT_KEY);"
+    STORAGE_URL: "https://$(STORAGE_ACCOUNT_NAME).blob.core.windows.net"
     STORAGE_CRIME_CONNECTION_STRING: "DefaultEndpointsProtocol=https;AccountName=$(STORAGE_CRIME_ACCOUNT_NAME);AccountKey=$(STORAGE_CRIME_ACCOUNT_KEY);EndpointSuffix=core.windows.net"
 
     BULK_SCAN_PROCESSOR_URL: http://bulk-scan-processor-aat.service.core-compute-aat.internal

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -16,7 +16,6 @@ java:
         - crime-storage-connection-string
         - flyway-password
         - blob-router-POSTGRES-PASS
-        - storage-reform-connection-string
   environment:
     DB_HOST: reform-scan-blob-router-{{ .Values.global.environment }}.postgres.database.azure.com
     DB_PORT: '5432'
@@ -32,6 +31,7 @@ java:
     HANDLE_REJECTED_FILES_CRON: "0/30 * * * * *"
     TASK_SCAN_DELAY: "4000" # in millis
 
+    STORAGE_URL: https://reformscan.{{ .Values.global.environment }}.platform.hmcts.net
     STORAGE_BULKSCAN_URL: https://bulkscan{{ .Values.global.environment }}.blob.core.windows.net
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
     STORAGE_BLOB_PUBLIC_KEY: "nonprod_public_key.der"

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -31,9 +31,17 @@ public class StorageConfiguration {
 
     @Bean
     public BlobServiceClient getStorageClient(
-        StorageSharedKeyCredential credentials,
-        @Value("${storage.reform.connection-string}") String connectionString
+        @Value("${storage.account-name}") String accountName,
+        @Value("${storage.account-key}") String accountKey,
+        @Value("${storage.url") String storageUrl
     ) {
+        String connectionString = String.format(
+            "DefaultEndpointsProtocol=https;BlobEndpoint=%s;AccountName=%s;AccountKey=%s",
+            storageUrl,
+            accountName,
+            accountKey
+        );
+
         return new BlobServiceClientBuilder()
             .connectionString(connectionString)
             .buildClient();

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -33,7 +33,7 @@ public class StorageConfiguration {
     public BlobServiceClient getStorageClient(
         @Value("${storage.account-name}") String accountName,
         @Value("${storage.account-key}") String accountKey,
-        @Value("${storage.url") String storageUrl
+        @Value("${storage.url}") String storageUrl
     ) {
         String connectionString = String.format(
             "DefaultEndpointsProtocol=https;BlobEndpoint=%s;AccountName=%s;AccountKey=%s",

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -16,6 +16,5 @@ spring:
         crime-storage-connection-string: storage.crime.connection-string
         flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD
-        storage-reform-connection-string: storage.reform.connection-string
         reports-email-username: SMTP_USERNAME
         reports-email-password: SMTP_PASSWORD


### PR DESCRIPTION
### Change description ###

Build connection string to reform scan storage in code, so that it doesn't need to be manually set in Key Vault.

Rafał's existing PR in cnp-flux-config (https://github.com/hmcts/cnp-flux-config/pull/2201) already matches chart version from this PR and no other changes are needed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
