### PR TITLE
Fix event recording of process start

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -78,6 +78,8 @@ public class BlobProcessor {
     private void processBlob(String blobName, String containerName) {
         logger.info("Processing {} from {} container", blobName, containerName);
 
+        envelopeService.saveEventFileProcessingStarted(containerName, blobName);
+
         BlobLeaseClient leaseClient = null;
 
         try {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -54,7 +54,6 @@ public class ContainerProcessor {
         Instant blobCreationDate = blob.getProperties().getLastModified().toInstant();
 
         if (blobReadinessChecker.isReady(blobCreationDate)) {
-            envelopeService.saveEventFileProcessingStarted(containerName, blob.getName());
             blobProcessor.process(blob.getName(), containerName);
         } else {
             logger.info(

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -82,6 +82,7 @@ class BlobProcessorTest {
 
         // then
         verify(blobDispatcher).dispatch(eq("envelope1.zip"), any(), eq(TARGET_CONTAINER), eq(TARGET_STORAGE_ACCOUNT));
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
         verify(envelopeService, never()).createDispatchedEnvelope(any(), any(), any());
     }
 
@@ -102,6 +103,7 @@ class BlobProcessorTest {
 
         // then
         verify(blobDispatcher, times(1)).dispatch(any(), any(), any(), any());
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
         verify(envelopeService).createDispatchedEnvelope(eq(SOURCE_CONTAINER), eq(fileName), any());
     }
 
@@ -150,6 +152,7 @@ class BlobProcessorTest {
         // then
         verify(blobDispatcher, times(1))
             .dispatch(eq(fileName), aryEq(BLOB_CONTENT), eq(targetContainerName), eq(BULKSCAN));
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
     }
 
     @Test
@@ -171,6 +174,7 @@ class BlobProcessorTest {
         // then
         verify(blobDispatcher, times(1))
             .dispatch(eq(fileName), aryEq(INTERNAL_ENVELOPE_CONTENT), eq(targetContainerName), eq(CRIME));
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
     }
 
     @Test
@@ -191,6 +195,7 @@ class BlobProcessorTest {
 
         // then
         verify(blobDispatcher, never()).dispatch(any(), any(), any(), any());
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
     }
 
     @Test
@@ -212,6 +217,7 @@ class BlobProcessorTest {
 
         // then
         verify(blobDispatcher, never()).dispatch(any(), any(), any(), any());
+        verify(envelopeService).saveEventFileProcessingStarted(SOURCE_CONTAINER, "envelope1.zip");
     }
 
     private static byte[] getBlobContent(Map<String, byte[]> zipEntries) {


### PR DESCRIPTION
### Change description ###

There is extra skip/check in blob processor. Moving to container processor instead so that blob processor only deals with actual routing without any skips

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
