### PR TITLE
Move envelope presence check to container processor

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -1,57 +1,91 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobContainerClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.blobrouter.data.DbHelper;
 import uk.gov.hmcts.reform.blobrouter.services.BlobReadinessChecker;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
+import java.time.Instant;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("db-test")
 class ContainerProcessorTest extends BlobStorageBaseTest {
 
+    private static final String CONTAINER_NAME = "my-container";
+
     @Autowired EnvelopeService envelopeService;
+    @Autowired DbHelper dbHelper;
 
     @Mock BlobProcessor blobProcessor;
     @Mock BlobReadinessChecker blobReadinessChecker;
 
+    private ContainerProcessor containerProcessor;
+    private BlobContainerClient containerClient;
+
+    @BeforeEach
+    void setUp() {
+        containerProcessor = new ContainerProcessor(
+            storageClient,
+            blobProcessor,
+            blobReadinessChecker,
+            envelopeService
+        );
+        containerClient = createContainer(CONTAINER_NAME);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dbHelper.deleteAll();
+        deleteAllContainers();
+    }
+
     @Test
     void should_read_files_from_provided_container_and_call_blob_processor_for_each_ready_blob() {
         // given
-        var containerName = "my-container";
-
-        var containerClient = createContainer(containerName);
-
         upload(containerClient, "1.zip");
         upload(containerClient, "2.zip");
         upload(containerClient, "3.zip");
 
         given(blobReadinessChecker.isReady(any())).willReturn(true, false, true);
 
-        var containerProcessor = new ContainerProcessor(
-            storageClient,
-            blobProcessor,
-            blobReadinessChecker,
-            envelopeService
-        );
-
         // when
-        containerProcessor.process(containerName);
+        containerProcessor.process(CONTAINER_NAME);
 
         // then
-        verify(blobProcessor).process("1.zip", containerName);
-        verify(blobProcessor).process("3.zip", containerName);
+        verify(blobProcessor).process("1.zip", CONTAINER_NAME);
+        verify(blobProcessor).process("3.zip", CONTAINER_NAME);
         verifyNoMoreInteractions(blobProcessor);
+    }
+
+    @Test
+    void should_not_call_blob_processor_when_file_already_exists_in_database() {
+        // given
+        upload(containerClient, "4.zip");
+        envelopeService.createDispatchedEnvelope(CONTAINER_NAME, "4.zip", Instant.now());
+        given(blobReadinessChecker.isReady(any())).willReturn(true);
+
+        // when
+        containerProcessor.process(CONTAINER_NAME);
+
+        // then
+        verify(blobProcessor, never()).process("4.zip", CONTAINER_NAME);
     }
 
     void upload(BlobContainerClient containerClient, String fileName) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -61,21 +61,6 @@ public class BlobProcessor {
     }
 
     public void process(String blobName, String containerName) {
-        envelopeService
-            .findEnvelope(blobName, containerName)
-            .ifPresentOrElse(
-                envelope -> logger.info(
-                    "Envelope already processed in system, skipping. ID: {}, filename: {}, container: {}, state: {}",
-                    envelope.id,
-                    envelope.fileName,
-                    envelope.container,
-                    envelope.status.name()
-                ),
-                () -> processBlob(blobName, containerName)
-            );
-    }
-
-    private void processBlob(String blobName, String containerName) {
         logger.info("Processing {} from {} container", blobName, containerName);
 
         envelopeService.saveEventFileProcessingStarted(containerName, blobName);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.OffsetDateTime;
 import java.util.Map;
-import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -254,7 +253,6 @@ class BlobProcessorTest {
         }
 
         given(blobProperties.getLastModified()).willReturn(time);
-        given(envelopeService.findEnvelope(any(), any())).willReturn(Optional.empty());
     }
 
     private void setupDownloadedBlobContent(byte[] content) {


### PR DESCRIPTION
### Change description ###

Leaving `BlobProcessor`'s responsibility to just process blob after all initial checks are done

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
