### PR TITLE
BUGFIX: Set `dispatched_at` to null when creating rejected envelope

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -43,7 +43,11 @@ public class EnvelopeService {
     public UUID createDispatchedEnvelope(String containerName, String blobName, Instant blobCreationDate) {
         eventRecordRepository.insert(new NewEventRecord(containerName, blobName, Event.DISPATCHED));
 
-        return createEnvelope(containerName, blobName, blobCreationDate, Status.DISPATCHED);
+        return envelopeRepository
+            .insert(
+                new NewEnvelope(containerName, blobName, blobCreationDate, now(), Status.DISPATCHED
+                )
+            );
     }
 
     @Transactional
@@ -55,17 +59,10 @@ public class EnvelopeService {
     ) {
         eventRecordRepository.insert(new NewEventRecord(containerName, blobName, Event.REJECTED, rejectionReason));
 
-        return createEnvelope(containerName, blobName, blobCreationDate, Status.REJECTED);
-    }
-
-    private UUID createEnvelope(String containerName, String blobName, Instant blobCreationDate, Status status) {
-        return envelopeRepository.insert(new NewEnvelope(
-            containerName,
-            blobName,
-            blobCreationDate,
-            now(),
-            status
-        ));
+        return envelopeRepository
+            .insert(
+                new NewEnvelope(containerName, blobName, blobCreationDate, null, Status.REJECTED)
+            );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -45,8 +45,7 @@ public class EnvelopeService {
 
         return envelopeRepository
             .insert(
-                new NewEnvelope(containerName, blobName, blobCreationDate, now(), Status.DISPATCHED
-                )
+                new NewEnvelope(containerName, blobName, blobCreationDate, now(), Status.DISPATCHED)
             );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -102,7 +102,7 @@ class EnvelopeServiceTest {
 
         assertThat(event.fileName).isEqualTo(BLOB_NAME);
         assertThat(event.container).isEqualTo(CONTAINER_NAME);
-        assertThat(event.event).isEqualTo(Event.DISPATCHED);
+        assertThat(event.event).isEqualTo(Event.REJECTED);
         assertThat(event.notes).isEqualTo(REJECTION_REASON);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -19,8 +19,6 @@ import java.util.UUID;
 
 import static java.time.Instant.now;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -73,6 +73,7 @@ class EnvelopeServiceTest {
         var envelope = newEnvelopeCaptor.getValue();
         var event = newEventRecordCaptor.getValue();
 
+        assertThat(envelope.fileName).isEqualTo(BLOB_NAME);
         assertThat(envelope.container).isEqualTo(CONTAINER_NAME);
         assertThat(envelope.dispatchedAt).isNotNull();
 


### PR DESCRIPTION
Existing test that tested both service methods at the same time was removed and two new tests were added.
Best to review in 'Split' mode.