### PR TITLE
Refactor : pass blob to blob processor

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -67,7 +67,6 @@ class BlobProcessorTest extends BlobStorageBaseTest {
 
         var blobProcessor =
             new BlobProcessor(
-                storageClient,
                 dispatcher,
                 envelopeService,
                 blobClient -> new BlobLeaseClientBuilder().blobClient(blobClient).buildClient(),
@@ -84,7 +83,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
             .upload(new ByteArrayInputStream(bytes), bytes.length);
 
         // when
-        blobProcessor.process(blobName, sourceContainer);
+        blobProcessor.process(sourceContainerClient.getBlobClient(blobName));
 
         // then
         assertThat(targetContainerClient.listBlobs())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +70,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
         containerProcessor.process(CONTAINER_NAME);
 
         // then
+        ArgumentCaptor<>
         verify(blobProcessor).process("1.zip", CONTAINER_NAME);
         verify(blobProcessor).process("3.zip", CONTAINER_NAME);
         verifyNoMoreInteractions(blobProcessor);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.specialized.BlobClientBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,11 +20,12 @@ import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.time.Instant;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
@@ -70,10 +73,12 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
         containerProcessor.process(CONTAINER_NAME);
 
         // then
-        ArgumentCaptor<>
-        verify(blobProcessor).process("1.zip", CONTAINER_NAME);
-        verify(blobProcessor).process("3.zip", CONTAINER_NAME);
-        verifyNoMoreInteractions(blobProcessor);
+        var blobArgCaptor = ArgumentCaptor.forClass(BlobClient.class);
+        verify(blobProcessor, times(2)).process(blobArgCaptor.capture());
+
+        assertThat(blobArgCaptor.getAllValues())
+            .extracting(BlobClientBase::getBlobName)
+            .containsExactly("1.zip", "3.zip");
     }
 
     @Test
@@ -87,7 +92,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
         containerProcessor.process(CONTAINER_NAME);
 
         // then
-        verify(blobProcessor, never()).process("4.zip", CONTAINER_NAME);
+        verify(blobProcessor, never()).process(any());
     }
 
     void upload(BlobContainerClient containerClient, String fileName) {


### PR DESCRIPTION
In the new flow, the first step will be creating a new envelope in DB.
One of the required columns is 'file_create_at', which was not possible before this change.
Now `BlobProcessor` receives an instance of `BlobClient` which has all the information needed (previously it was creating it from a `BlobServiceClient`
