### PR TITLE
Add service method for marking envelope as rejected

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptions/EnvelopeNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptions/EnvelopeNotFoundException.java
@@ -1,4 +1,10 @@
 package uk.gov.hmcts.reform.blobrouter.exceptions;
 
 public class EnvelopeNotFoundException extends RuntimeException {
+    public EnvelopeNotFoundException() {
+    }
+
+    public EnvelopeNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.blobrouter.data.model.EventRecord;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.model.NewEventRecord;
 import uk.gov.hmcts.reform.blobrouter.data.model.Status;
+import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;
 
 import java.time.Instant;
 import java.util.List;
@@ -84,6 +85,21 @@ public class EnvelopeService {
     @Transactional(readOnly = true)
     public List<Envelope> getReadyToDeleteDispatches(String containerName) {
         return envelopeRepository.find(Status.DISPATCHED, containerName, false);
+    }
+
+    @Transactional
+    public void markAsRejected(UUID id) {
+        envelopeRepository
+            .find(id)
+            .ifPresentOrElse(
+                env -> {
+                    envelopeRepository.updateStatus(id, Status.REJECTED);
+                    eventRecordRepository.insert(new NewEventRecord(env.container, env.fileName, Event.REJECTED));
+                },
+                () -> {
+                    throw new EnvelopeNotFoundException("Envelope with ID: " + id + " not found");
+                }
+            );
     }
 
     @Transactional


### PR DESCRIPTION
In the new flow we will not create an envelope in REJECTED status.
Instead, we'll update existing envelope (and create a new event).

Adding a method that will allow this.