### PR TITLE
Add test certificate thumbprints in API Mgmt for perftest

### DIFF
--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -1,1 +1,5 @@
+api_test_valid_certificate_thumbprint         = "8DEF7C798A1ECF35A7C6B5383610F4B4B23F0264"
+api_test_expired_certificate_thumbprint       = "6BC1BCBCA99A606E0760AD36012B48C0BBDF96BF"
+api_test_not_yet_valid_certificate_thumbprint = "4345BBFC1FA6CA783428D17EE04A266AD5A14F3A"
+
 allowed_client_certificate_thumbprints = ["2A1EE53E044632145C89FE428128080353127DF6"]


### PR DESCRIPTION
### Change description ###

Configure test certificate thumbprints in API Mgmt for perftest.

This PR is same as #311, which seemed to have permanently broken build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
