### PR TITLE
Use new db values as the db migration needs to be applied on new db

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -113,31 +113,31 @@ resource "azurerm_key_vault_secret" "error_notifications_username" {
 resource "azurerm_key_vault_secret" "POSTGRES-USER" {
   name         = "${var.component}-POSTGRES-USER"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-  value        = "${module.blob-router-db.user_name}"
+  value        = "${module.reform-blob-router-db.user_name}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES-PASS" {
   name         = "${var.component}-POSTGRES-PASS"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-  value        = "${module.blob-router-db.postgresql_password}"
+  value        = "${module.reform-blob-router-db.postgresql_password}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
   name         = "${var.component}-POSTGRES-HOST"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-  value        = "${module.blob-router-db.host_name}"
+  value        = "${module.reform-blob-router-db.host_name}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
   name         = "${var.component}-POSTGRES-PORT"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-  value        = "${module.blob-router-db.postgresql_listen_port}"
+  value        = "${module.reform-blob-router-db.postgresql_listen_port}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
   name         = "${var.component}-POSTGRES-DATABASE"
   key_vault_id = "${data.azurerm_key_vault.reform_scan_key_vault.id}"
-  value        = "${module.blob-router-db.postgresql_database}"
+  value        = "${module.reform-blob-router-db.postgresql_database}"
 }
 
 # Copy postgres password for flyway migration


### PR DESCRIPTION
### Change description ###

- Currently app is using new database but DB migration runs on old database.

- Pipeline needs secrets modified in PR to be updated to new database values.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
