### PR TITLE
Make it configurable whether the app uses proxy or not

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.31
+version: 0.0.32
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.32
+version: 0.0.33
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/HttpConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/HttpConfiguration.java
@@ -9,6 +9,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -35,7 +36,8 @@ public class HttpConfiguration {
     }
 
     @Bean
-    public HttpClient azureHttpClient(
+    @ConditionalOnProperty(prefix = "proxy", name = "enabled", havingValue = "true")
+    public HttpClient azureHttpClientWithProxy(
         @Value("${proxy.host-name}") String proxyHostName,
         @Value("${proxy.port}") int proxyPort
     ) {
@@ -50,6 +52,12 @@ public class HttpConfiguration {
                 )
             )
             .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "proxy", name = "enabled", havingValue = "false")
+    public HttpClient azureHttpClientWithoutProxy() {
+        return new NettyAsyncHttpClientBuilder().build();
     }
 
     private CloseableHttpClient getHttpClient() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -97,5 +97,6 @@ scheduling:
 
 
 proxy:
+  enabled: ${PROXY_ENABLED:true}
   host-name: proxyout.reform.hmcts.net
   port: 8080


### PR DESCRIPTION
### Change description ###

Make it configurable whether the app uses proxy or not. Proxy can't be used in perftest, as it doesn't work there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
