### PR TITLE
Get rid off flyway variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,12 +284,13 @@ import org.flywaydb.gradle.task.FlywayMigrateTask
 flyway {
   user = System.getenv('DB_USER')
   password = System.getenv('DB_PASSWORD')
+
   def dbHost = System.getenv('DB_HOST')
   def dbPort = System.getenv('DB_PORT')
   def dbConOption = System.getenv('DB_CONN_OPTIONS')
   def dbName = System.getenv('DB_NAME')
 
-  url=  "jdbc:postgresql://${dbHost}:${dbPort}/${dbName}${dbConOption}"
+  url = "jdbc:postgresql://${dbHost}:${dbPort}/${dbName}${dbConOption}"
 
   baselineOnMigrate = true
   baselineVersion = '000'

--- a/build.gradle
+++ b/build.gradle
@@ -282,9 +282,15 @@ bootJar {
 import org.flywaydb.gradle.task.FlywayMigrateTask
 
 flyway {
-  url = System.getenv('FLYWAY_URL')
-  user = System.getenv('FLYWAY_USER')
-  password = System.getenv('FLYWAY_PASSWORD')
+  user = System.getenv('DB_USER')
+  password = System.getenv('DB_PASSWORD')
+  def dbHost = System.getenv('DB_HOST')
+  def dbPort = System.getenv('DB_PORT')
+  def dbConOption = System.getenv('DB_CONN_OPTIONS')
+  def dbName = System.getenv('DB_NAME')
+
+  url=  "jdbc:postgresql://${dbHost}:${dbPort}/${dbName}${dbConOption}"
+
   baselineOnMigrate = true
   baselineVersion = '000'
 }

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.32
+version: 0.0.34
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.preview.template.yaml
+++ b/charts/reform-scan-blob-router/values.preview.template.yaml
@@ -33,9 +33,7 @@ java:
     TASK_SCAN_DELAY: "1000" # in millis
 
     FLYWAY_SKIP_MIGRATIONS: false
-    FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
-    FLYWAY_USER: "{{ .Values.postgresql.postgresqlUsername}}"
-    FLYWAY_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
+
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
 
     STORAGE_BULKSCAN_URL: https://bulkscan.aat.platform.hmcts.net

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -14,7 +14,6 @@ java:
         - storage-account-primary-key
         - storage-account-secondary-key
         - crime-storage-connection-string
-        - db-flyway-password
         - blob-router-POSTGRES-PASS
   environment:
     DB_HOST: blob-router-{{ .Values.global.environment }}.postgres.database.azure.com
@@ -23,8 +22,6 @@ java:
     DB_USER: blob_router@blob-router-{{ .Values.global.environment }}
     DB_CONN_OPTIONS: ?sslmode=require
 
-    FLYWAY_URL: jdbc:postgresql://blob-router-{{ .Values.global.environment }}.postgres.database.azure.com:5432/blob_router?sslmode=require
-    FLYWAY_USER: blob_router@blob-router-{{ .Values.global.environment }}
     FLYWAY_SKIP_MIGRATIONS: true
 
     DELETE_DISPATCHED_FILES_CRON: "0 0/10 * * * *"

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -13,8 +13,8 @@ clients.error-notifications.username=username
 flyway.skip-migrations=false
 
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/blob_router
-spring.flyway.url=jdbc:tc:postgresql:9.6://localhost/blob_router
+spring.datasource.url=jdbc:tc:postgresql:11.0://localhost/blob_router
+spring.flyway.url=jdbc:tc:postgresql:11.0://localhost/blob_router
 
 storage-blob-processing-delay-in-minutes=0
 public-key-der-file=signing/test_public_key.der

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -14,6 +14,7 @@ flyway.skip-migrations=false
 
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/blob_router
+spring.flyway.url=jdbc:tc:postgresql:9.6://localhost/blob_router
 
 storage-blob-processing-delay-in-minutes=0
 public-key-der-file=signing/test_public_key.der

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,10 @@ spring:
           starttls:
             enable: true
     test-connection: false
+  flyway:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${DB_CONN_OPTIONS}
+    user: ${DB_USER}
+    password: ${DB_PASSWORD}
 
 service:
   storage-config:

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -14,7 +14,6 @@ spring:
         storage-account-primary-key:  storage.account-key
         storage-account-secondary-key:  storage.account-secondary-key
         crime-storage-connection-string: storage.crime.connection-string
-        db-flyway-password: flyway.password
         blob-router-POSTGRES-PASS: DB_PASSWORD
         reports-email-username: SMTP_USERNAME
         reports-email-password: SMTP_PASSWORD


### PR DESCRIPTION


### Change description ###

get rid of flyway variables. instead use db variables 
next pr will try to use db vars from vault.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
