### PR TITLE
Return envelopes from `DuplicateFinder`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
@@ -44,17 +44,17 @@ public class DuplicateFileHandler {
                             logger.info(
                                 "Moving duplicate file to rejected container. Container: {}, File name: {}",
                                 container,
-                                duplicate.getName()
+                                duplicate.fileName
                             );
 
-                            blobMover.moveToRejectedContainer(duplicate.getName(), container);
-                            envelopeService.saveEvent(container, duplicate.getName(), EventType.DUPLICATE_REJECTED);
+                            blobMover.moveToRejectedContainer(duplicate.fileName, container);
+                            envelopeService.saveEvent(container, duplicate.fileName, EventType.DUPLICATE_REJECTED);
 
                         } catch (Exception exc) {
                             logger.error(
                                 "Error moving duplicate file. Container: {}. File name: {}",
                                 container,
-                                duplicate.getName(),
+                                duplicate.fileName,
                                 exc
                             );
                         }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
@@ -31,7 +31,7 @@ public class DuplicateFinder {
             .stream()
             .map(blob -> envelopeService.findEnvelope(blob.getName(), containerName))
             .flatMap(Optional::stream)
-            .filter(envelope -> envelope.isDeleted)
+            .filter(envelope -> envelope.isDeleted) // is deleted -> has already been processed before
             .collect(toList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.models.BlobItem;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 
@@ -23,19 +24,14 @@ public class DuplicateFinder {
         this.envelopeService = envelopeService;
     }
 
-    public List<BlobItem> findIn(String containerName) {
+    public List<Envelope> findIn(String containerName) {
         return storageClient
             .getBlobContainerClient(containerName)
             .listBlobs()
             .stream()
-            .filter(blob -> hasAlreadyBeenProcessed(blob.getName(), containerName))
+            .map(blob -> envelopeService.findEnvelope(blob.getName(), containerName))
+            .flatMap(Optional::stream)
+            .filter(envelope -> envelope.isDeleted)
             .collect(toList());
-    }
-
-    private boolean hasAlreadyBeenProcessed(String fileName, String containerName) {
-        return envelopeService
-            .findEnvelope(fileName, containerName)
-            .map(e -> e.isDeleted)
-            .orElse(false);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinderTest.java
@@ -54,12 +54,11 @@ class DuplicateFinderTest {
         given(envelopeService.findEnvelope("c.zip", "container")).willReturn(Optional.of(notYetDeletedEnvelope));
 
         // when
-        List<BlobItem> result = new DuplicateFinder(storageClient, envelopeService).findIn("container");
+        List<Envelope> result = new DuplicateFinder(storageClient, envelopeService).findIn("container");
 
         // then
         assertThat(result)
-            .extracting(BlobItem::getName)
-            .containsExactly("b.zip");
+            .containsExactly(deletedEnvelope);
     }
 
 


### PR DESCRIPTION
Changing the return type
from `BlobItem` (which contains 'name' and 'container')
to `Envelope` (which contains above + envelope ID)

This is in preparation to **new events flow**, where event has a foreign key to envelope.
The ID of envelope will be needed to create an event.

https://tools.hmcts.net/jira/browse/BPS-1065