### PR TITLE
Use new event model

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ControllerTestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ControllerTestBase.java
@@ -4,11 +4,11 @@ import net.javacrumbs.shedlock.core.LockProvider;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.blobrouter.config.ShedLockConfig;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventRecordRepository;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEventRepository;
 
 public class ControllerTestBase {
     @MockBean protected EnvelopeRepository envelopeRepo;
-    @MockBean protected EventRecordRepository eventRecordRepo;
+    @MockBean protected EnvelopeEventRepository eventRecordRepo;
     @MockBean protected LockProvider lockProvider;
     @MockBean protected ShedLockConfig shedLockConfig;
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventRecord;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 
 import java.util.Arrays;
@@ -45,26 +45,24 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             Status.DISPATCHED,
             false
         );
-        EventRecord eventRecordInDb1 = new EventRecord(
+        var eventRecordInDb1 = new EnvelopeEvent(
             1,
-            container,
-            fileName,
-            now(),
+            envelopeInDb.id,
             EventType.FILE_PROCESSING_STARTED,
-            null
+            null,
+            now()
         );
-        EventRecord eventRecordInDb2 = new EventRecord(
+        var eventRecordInDb2 = new EnvelopeEvent(
             2,
-            container,
-            fileName,
-            now(),
+            envelopeInDb.id,
             EventType.DISPATCHED,
-            null
+            null,
+            now()
         );
 
         given(envelopeRepo.find(fileName, container))
             .willReturn(Optional.of(envelopeInDb));
-        given(eventRecordRepo.find(container, fileName))
+        given(eventRecordRepo.findForEnvelope(envelopeInDb.id))
             .willReturn(Arrays.asList(
                 eventRecordInDb1,
                 eventRecordInDb2

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventRecord;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.model.out.EnvelopeEventResponse;
 import uk.gov.hmcts.reform.blobrouter.model.out.EnvelopeInfo;
@@ -37,7 +37,7 @@ public class EnvelopeController {
             .orElseThrow(EnvelopeNotFoundException::new);
     }
 
-    private EnvelopeInfo toResponse(Envelope dbEnvelope, List<EventRecord> dbEventRecords) {
+    private EnvelopeInfo toResponse(Envelope dbEnvelope, List<EnvelopeEvent> dbEventRecords) {
         return new EnvelopeInfo(
             dbEnvelope.id,
             dbEnvelope.container,
@@ -49,7 +49,7 @@ public class EnvelopeController {
             dbEnvelope.isDeleted,
             dbEventRecords
                 .stream()
-                .map(e -> new EnvelopeEventResponse(e.id, e.createdAt, e.event.name(), e.notes))
+                .map(e -> new EnvelopeEventResponse(e.id, e.createdAt, e.type.name(), e.notes))
                 .collect(toList())
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -8,10 +8,12 @@ import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEventRepository;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventRecord;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventRecordRepository;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
-import uk.gov.hmcts.reform.blobrouter.data.events.NewEventRecord;
+import uk.gov.hmcts.reform.blobrouter.data.events.NewEnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;
 
 import java.time.Instant;
@@ -25,14 +27,14 @@ import static java.time.Instant.now;
 public class EnvelopeService {
 
     private final EnvelopeRepository envelopeRepository;
-    private final EventRecordRepository eventRecordRepository;
+    private final EnvelopeEventRepository eventRepository;
 
     public EnvelopeService(
         EnvelopeRepository envelopeRepository,
-        EventRecordRepository eventRecordRepository
+        EnvelopeEventRepository eventRepository
     ) {
         this.envelopeRepository = envelopeRepository;
-        this.eventRecordRepository = eventRecordRepository;
+        this.eventRepository = eventRepository;
     }
 
     @Transactional(readOnly = true)
@@ -47,7 +49,7 @@ public class EnvelopeService {
                 new NewEnvelope(containerName, blobName, blobCreationDate, null, Status.CREATED)
             );
 
-        eventRecordRepository.insert(new NewEventRecord(containerName, blobName, EventType.FILE_PROCESSING_STARTED));
+        eventRepository.insert(new NewEnvelopeEvent(id, EventType.FILE_PROCESSING_STARTED, null));
 
         return id;
     }
@@ -70,7 +72,7 @@ public class EnvelopeService {
                 env -> {
                     envelopeRepository.updateStatus(id, Status.DISPATCHED);
                     envelopeRepository.updateDispatchDateTime(id, now());
-                    eventRecordRepository.insert(new NewEventRecord(env.container, env.fileName, EventType.DISPATCHED));
+                    eventRepository.insert(new NewEnvelopeEvent(id, EventType.DISPATCHED, null));
                 },
                 () -> {
                     throw new EnvelopeNotFoundException("Envelope with ID: " + id + " not found");
@@ -85,7 +87,7 @@ public class EnvelopeService {
             .ifPresentOrElse(
                 env -> {
                     envelopeRepository.updateStatus(id, Status.REJECTED);
-                    eventRecordRepository.insert(new NewEventRecord(env.container, env.fileName, EventType.REJECTED));
+                    eventRepository.insert(new NewEnvelopeEvent(id, EventType.REJECTED, null));
                 },
                 () -> {
                     throw new EnvelopeNotFoundException("Envelope with ID: " + id + " not found");
@@ -96,20 +98,20 @@ public class EnvelopeService {
     @Transactional
     public void markEnvelopeAsDeleted(Envelope envelope) {
         envelopeRepository.markAsDeleted(envelope.id);
-        eventRecordRepository.insert(new NewEventRecord(envelope.container, envelope.fileName, EventType.DELETED));
+        eventRepository.insert(new NewEnvelopeEvent(envelope.id, EventType.DELETED, null));
     }
 
     @Transactional
-    public void saveEvent(String containerName, String blobName, EventType eventType) {
-        eventRecordRepository.insert(new NewEventRecord(containerName, blobName, eventType));
+    public void saveEvent(UUID envelopeId, EventType eventType) {
+        eventRepository.insert(new NewEnvelopeEvent(envelopeId, eventType, null));
     }
 
     @Transactional(readOnly = true)
-    public Optional<Tuple2<Envelope, List<EventRecord>>> getEnvelopeInfo(String blobName, String containerName) {
+    public Optional<Tuple2<Envelope, List<EnvelopeEvent>>> getEnvelopeInfo(String blobName, String containerName) {
         return findEnvelope(blobName, containerName)
             .map(envelope -> Tuples.of(
                 envelope,
-                eventRecordRepository.find(containerName, blobName)
+                eventRepository.findForEnvelope(envelope.id)
             ));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -10,8 +10,6 @@ import uk.gov.hmcts.reform.blobrouter.data.envelopes.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEventRepository;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventRecord;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventRecordRepository;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 import uk.gov.hmcts.reform.blobrouter.data.events.NewEnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
@@ -44,17 +44,17 @@ public class DuplicateFileHandler {
                             logger.info(
                                 "Moving duplicate file to rejected container. Container: {}, File name: {}",
                                 container,
-                                duplicate.getName()
+                                duplicate.fileName
                             );
 
-                            blobMover.moveToRejectedContainer(duplicate.getName(), container);
-                            envelopeService.saveEvent(container, duplicate.getName(), EventType.DUPLICATE_REJECTED);
+                            blobMover.moveToRejectedContainer(duplicate.fileName, container);
+                            envelopeService.saveEvent(duplicate.id, EventType.DUPLICATE_REJECTED);
 
                         } catch (Exception exc) {
                             logger.error(
                                 "Error moving duplicate file. Container: {}. File name: {}",
                                 container,
-                                duplicate.getName(),
+                                duplicate.fileName,
                                 exc
                             );
                         }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/DuplicateFileHandler.java
@@ -48,7 +48,7 @@ public class DuplicateFileHandler {
                             );
 
                             blobMover.moveToRejectedContainer(duplicate.fileName, container);
-                            envelopeService.saveEvent(container, duplicate.fileName, EventType.DUPLICATE_REJECTED);
+                            envelopeService.saveEvent(duplicate.id, EventType.DUPLICATE_REJECTED);
 
                         } catch (Exception exc) {
                             logger.error(

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
 import uk.gov.hmcts.reform.blobrouter.config.StorageConfigItem;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.services.BlobVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -175,6 +175,6 @@ public class BlobProcessor {
 
     private void handleError(Exception exc, BlobClient blob) {
         logger.error("Error occurred while processing {} from {}", blob.getBlobName(), blob.getContainerName(), exc);
-        envelopeService.saveEvent(blob.getContainerName(), blob.getBlobName(), EventType.ERROR);
+        // TODO: save error event
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -254,7 +254,7 @@ class BlobProcessorTest {
 
         // then
         verify(envelopeService, times(0)).createNewEnvelope(any(), any(), any());
-        verify(envelopeService, times(0)).saveEvent(any(), any(), any());
+        verify(envelopeService, times(0)).saveEvent(any(), any());
         verify(verifier, times(0)).verifyZip(any(), any());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleanerTest.java
@@ -11,10 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.RejectedBlobChecker;
 
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -102,6 +105,10 @@ class RejectedContainerCleanerTest {
         given(blobClient2.getContainerName()).willReturn(REJECTED_CONTAINER);
         given(blobClient2.getBlobName()).willReturn(REJECTED_BLOB);
 
+        var envelopeId = UUID.randomUUID();
+        given(envelopeService.findEnvelope(REJECTED_BLOB, REJECTED_CONTAINER))
+            .willReturn(Optional.of(new Envelope(envelopeId, null, null, null, null, null, null, true)));
+
         // when
         cleaner.cleanUp();
 
@@ -113,6 +120,6 @@ class RejectedContainerCleanerTest {
         verify(blobClient2, times(1)).delete();
 
         // and
-        verify(envelopeService).saveEvent(REJECTED_CONTAINER, REJECTED_BLOB, EventType.DELETED_FROM_REJECTED);
+        verify(envelopeService).saveEvent(envelopeId, EventType.DELETED_FROM_REJECTED);
     }
 }


### PR DESCRIPTION
Switch to using the new event model/repo/table (main difference being event having **envelope ID**).
Old model (along with tests) will be removed in separate PR.

https://tools.hmcts.net/jira/browse/BPS-1065