### PR TITLE
Extract acquiring blob lease to a separate class

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobItem;
-import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +17,7 @@ import uk.gov.hmcts.reform.blobrouter.services.BlobVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProvider;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
+import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.io.ByteArrayInputStream;
@@ -45,6 +45,9 @@ class BlobProcessorTest extends BlobStorageBaseTest {
     private ServiceConfiguration serviceConfiguration;
 
     @Autowired
+    private LeaseAcquirer leaseAcquirer;
+
+    @Autowired
     private DbHelper dbHelper;
 
     @BeforeEach
@@ -69,7 +72,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
             new BlobProcessor(
                 dispatcher,
                 envelopeService,
-                blobClient -> new BlobLeaseClientBuilder().blobClient(blobClient).buildClient(),
+                leaseAcquirer,
                 new BlobVerifier("signing/test_public_key.der"),
                 serviceConfiguration
             );

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -1,11 +1,16 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class LeaseAcquirer {
+    public static final int LEASE_DURATION_IN_SECONDS = 60;
 
     private final LeaseClientProvider leaseClientProvider;
 
@@ -13,11 +18,17 @@ public class LeaseAcquirer {
         this.leaseClientProvider = leaseClientProvider;
     }
 
-    public BlobLeaseClient acquireFor(BlobClient blobClient) {
-        var leaseClient = leaseClientProvider.get(blobClient);
+    public Optional<BlobLeaseClient> acquireFor(BlobClient blobClient) {
         try {
-            leaseClient.acquireLease(60);
-            return leaseClient;
-        } catch ()
+            var leaseClient = leaseClientProvider.get(blobClient);
+            leaseClient.acquireLease(LEASE_DURATION_IN_SECONDS);
+            return Optional.of(leaseClient);
+        } catch (BlobStorageException exc) {
+            if (exc.getErrorCode() == BlobErrorCode.LEASE_ALREADY_PRESENT) {
+                return Optional.empty();
+            } else {
+                throw exc;
+            }
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -4,13 +4,18 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 @Component
 public class LeaseAcquirer {
+
     public static final int LEASE_DURATION_IN_SECONDS = 60;
+    private static final Logger logger = getLogger(LeaseAcquirer.class);
 
     private final LeaseClientProvider leaseClientProvider;
 
@@ -23,12 +28,18 @@ public class LeaseAcquirer {
             var leaseClient = leaseClientProvider.get(blobClient);
             leaseClient.acquireLease(LEASE_DURATION_IN_SECONDS);
             return Optional.of(leaseClient);
+
         } catch (BlobStorageException exc) {
-            if (exc.getErrorCode() == BlobErrorCode.LEASE_ALREADY_PRESENT) {
-                return Optional.empty();
-            } else {
-                throw exc;
+            if (exc.getErrorCode() != BlobErrorCode.LEASE_ALREADY_PRESENT) {
+                logger.error(
+                    "Error acquiring lease for blob. File name: {}, Container: {}",
+                    blobClient.getBlobName(),
+                    blobClient.getContainerName(),
+                    exc
+                );
             }
+
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.specialized.BlobLeaseClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeaseAcquirer {
+
+    private final LeaseClientProvider leaseClientProvider;
+
+    public LeaseAcquirer(LeaseClientProvider leaseClientProvider) {
+        this.leaseClientProvider = leaseClientProvider;
+    }
+
+    public BlobLeaseClient acquireFor(BlobClient blobClient) {
+        var leaseClient = leaseClientProvider.get(blobClient);
+        try {
+            leaseClient.acquireLease(60);
+            return leaseClient;
+        } catch ()
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
@@ -14,7 +13,7 @@ import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
 import uk.gov.hmcts.reform.blobrouter.services.BlobVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
-import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseClientProvider;
+import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers;
 
 import java.io.ByteArrayInputStream;
@@ -37,7 +36,7 @@ public class BlobProcessor {
 
     private final BlobDispatcher dispatcher;
     private final EnvelopeService envelopeService;
-    private final LeaseClientProvider leaseClientProvider;
+    private final LeaseAcquirer leaseAcquirer;
     private final BlobVerifier blobVerifier;
 
     // container-specific configuration, by container name
@@ -46,13 +45,13 @@ public class BlobProcessor {
     public BlobProcessor(
         BlobDispatcher dispatcher,
         EnvelopeService envelopeService,
-        LeaseClientProvider leaseClientProvider,
+        LeaseAcquirer leaseAcquirer,
         BlobVerifier blobVerifier,
         ServiceConfiguration serviceConfiguration
     ) {
         this.dispatcher = dispatcher;
         this.envelopeService = envelopeService;
-        this.leaseClientProvider = leaseClientProvider;
+        this.leaseAcquirer = leaseAcquirer;
         this.blobVerifier = blobVerifier;
         this.storageConfig = serviceConfiguration.getStorageConfig();
     }
@@ -64,60 +63,61 @@ public class BlobProcessor {
 
         logger.info("Processing {} from {} container", blobName, containerName);
 
-        BlobLeaseClient leaseClient = null;
-        try {
-            leaseClient = leaseClientProvider.get(blobClient);
-            leaseClient.acquireLease(60);
+        leaseAcquirer
+            .acquireFor(blobClient)
+            .ifPresentOrElse(
+                leaseClient -> {
+                    try {
+                        UUID id = envelopeService.createNewEnvelope(containerName, blobName, blobCreationDate);
 
-            UUID id = envelopeService.createNewEnvelope(containerName, blobName, blobCreationDate);
+                        byte[] rawBlob = tryToDownloadBlob(blobClient);
 
-            byte[] rawBlob = tryToDownloadBlob(blobClient);
+                        var verificationResult = blobVerifier.verifyZip(blobName, rawBlob);
 
-            var verificationResult = blobVerifier.verifyZip(blobName, rawBlob);
+                        if (verificationResult.isOk) {
+                            StorageConfigItem containerConfig = storageConfig.get(containerName);
+                            TargetStorageAccount targetStorageAccount = containerConfig.getTargetStorageAccount();
+                            var targetContainerName = containerConfig.getTargetContainer();
 
-            if (verificationResult.isOk) {
-                StorageConfigItem containerConfig = storageConfig.get(containerName);
-                TargetStorageAccount targetStorageAccount = containerConfig.getTargetStorageAccount();
-                var targetContainerName = containerConfig.getTargetContainer();
+                            dispatcher.dispatch(
+                                blobName,
+                                getContentToUpload(rawBlob, targetStorageAccount),
+                                targetContainerName,
+                                targetStorageAccount
+                            );
 
-                dispatcher.dispatch(
+                            envelopeService.markAsDispatched(id);
+
+                            logger.info(
+                                "Finished processing {} from {} container. New envelope ID: {}",
+                                blobName,
+                                containerName,
+                                id
+                            );
+                        } else {
+                            envelopeService.markAsRejected(id);
+
+                            logger.error(
+                                "Rejected Blob. File name: {}, Container: {}, New envelope ID: {}, Reason: {}",
+                                blobName,
+                                containerName,
+                                id,
+                                verificationResult.error
+                            );
+                            // TODO send notification to Exela
+                        }
+                    } catch (Exception exception) {
+                        handleError(exception, blobClient);
+                    } finally {
+                        tryToReleaseLease(leaseClient, blobName, containerName);
+                    }
+                },
+                () -> logger.info(
+                    "Cannot acquire a lease for blob. File name: {}, container: {}",
                     blobName,
-                    getContentToUpload(rawBlob, targetStorageAccount),
-                    targetContainerName,
-                    targetStorageAccount
-                );
-
-                envelopeService.markAsDispatched(id);
-
-                logger.info(
-                    "Finished processing {} from {} container. New envelope ID: {}",
-                    blobName,
-                    containerName,
-                    id
-                );
-            } else {
-                envelopeService.markAsRejected(id);
-
-                logger.error(
-                    "Rejected Blob. File name: {}, Container: {}, New envelope ID: {}, Reason: {}",
-                    blobName,
-                    containerName,
-                    id,
-                    verificationResult.error
-                );
-                // TODO send notification to Exela
-            }
-        } catch (BlobStorageException exc) {
-            if (exc.getErrorCode() == BlobErrorCode.LEASE_ALREADY_PRESENT) {
-                logger.info("Cannot acquire a lease for blob. File name: {}, container: {}", blobName, containerName);
-            } else {
-                handleError(exc, blobClient);
-            }
-        } catch (Exception exception) {
-            handleError(exception, blobClient);
-        } finally {
-            tryToReleaseLease(leaseClient, blobName, containerName);
-        }
+                    containerName
+                )
+            );
     }
 
     private byte[] getContentToUpload(
@@ -155,9 +155,7 @@ public class BlobProcessor {
 
     private void tryToReleaseLease(BlobLeaseClient leaseClient, String blobName, String containerName) {
         try {
-            if (leaseClient != null) {
-                leaseClient.releaseLease();
-            }
+            leaseClient.releaseLease();
         } catch (BlobStorageException exception) {
             // this will mean there was a problem acquiring lease in the first place
             // or call to release the lease genuinely went wrong.

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -113,7 +113,7 @@ public class BlobProcessor {
                     }
                 },
                 () -> logger.info(
-                    "Cannot acquire a lease for blob. File name: {}, container: {}",
+                    "Cannot acquire a lease for blob - skipping. File name: {}, container: {}",
                     blobName,
                     containerName
                 )

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.blobrouter.services.storage;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.specialized.BlobLeaseClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LeaseAcquirerTest {
+
+    @Mock BlobClient blobClient;
+    @Mock BlobLeaseClient leaseClient;
+    @Mock BlobStorageException blobStorageException;
+
+    @Test
+    void should_return_lease_client_if_acquiring_lease_succeeded() {
+        // given
+        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
+
+        // when
+        Optional<BlobLeaseClient> result = leaseAcquirer.acquireFor(blobClient);
+
+        // then
+        assertThat(result).contains(leaseClient);
+        verify(leaseClient).acquireLease(LeaseAcquirer.LEASE_DURATION_IN_SECONDS);
+    }
+
+    @Test
+    void should_return_empty_optional_if_lease_for_given_blob_has_already_been_acquired() {
+        // given
+        given(blobStorageException.getErrorCode()).willReturn(BlobErrorCode.LEASE_ALREADY_PRESENT);
+        doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
+
+        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
+
+        // when
+        Optional<BlobLeaseClient> result = leaseAcquirer.acquireFor(blobClient);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_throw_exception_if_lease_cannot_be_acquired_for_unknown_reason() {
+        // given
+        given(blobStorageException.getErrorCode()).willReturn(BlobErrorCode.INTERNAL_ERROR);
+        doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
+
+        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
+
+        // when
+        var exc = catchThrowable(() -> leaseAcquirer.acquireFor(blobClient));
+
+        // then
+        assertThat(exc).isEqualTo(blobStorageException);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -51,20 +50,5 @@ class LeaseAcquirerTest {
 
         // then
         assertThat(result).isEmpty();
-    }
-
-    @Test
-    void should_throw_exception_if_lease_cannot_be_acquired_for_unknown_reason() {
-        // given
-        given(blobStorageException.getErrorCode()).willReturn(BlobErrorCode.INTERNAL_ERROR);
-        doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
-
-        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
-
-        // when
-        var exc = catchThrowable(() -> leaseAcquirer.acquireFor(blobClient));
-
-        // then
-        assertThat(exc).isEqualTo(blobStorageException);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobProperties;
-import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,12 +27,10 @@ import java.util.zip.ZipOutputStream;
 
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.will;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Trying to make the main service (`BlobProcessor`) a bit slimmer, before adding new stuff related to envelope lifecycle.

Best to review in split view.
Most code moved to `ifPresent` on optional lease (previously all in one try with conditional logic in catch block)