### PR TITLE
Update New Envelopes Finder service to check new envelopes in business hours only

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ClockConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/ClockConfig.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.blobrouter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.blobrouter.util.TimeZones;
+
+import java.time.Clock;
+import javax.validation.ClockProvider;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public ClockProvider clockProvider() {
+        return () -> Clock.system(TimeZones.EUROPE_LONDON_ZONE_ID);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinder.java
@@ -8,10 +8,16 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
 
+import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.validation.ClockProvider;
 
 import static java.util.Collections.singleton;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -29,28 +35,40 @@ public class NewEnvelopesFinder {
 
     private static final String CRIME_CONTAINER = "crime";
 
+    private final Clock clock;
+
+    private static final int START_HOUR = 9;
+    private static final int END_HOUR = 18;
+    private static final List<DayOfWeek> WEEKEND = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
     public NewEnvelopesFinder(
         EnvelopeRepository envelopeRepository,
         ServiceConfiguration serviceConfig,
-        @Value("${scheduling.task.check-new-envelopes.time-interval}") Duration timeInterval
+        @Value("${scheduling.task.check-new-envelopes.time-interval}") Duration timeInterval,
+        ClockProvider clockProvider
     ) {
         Validate.isTrue(timeInterval != null, "Time interval is required");
         this.envelopeRepository = envelopeRepository;
         this.serviceConfig = serviceConfig;
         this.timeInterval = timeInterval;
+        this.clock = clockProvider.getClock();
     }
 
     public void checkNewCftEnvelopesCreated() {
-        checkNewEnvelopesInContainers(getCftContainers(), "CFT");
+        if (isCurrentTimeInBusinessHours(clock)) {
+            checkNewEnvelopesInContainers(getCftContainers(), "CFT");
+        }
     }
 
     public void checkNewCrimeEnvelopesCreated() {
-        if (serviceConfig.getEnabledSourceContainers().contains(CRIME_CONTAINER)) {
-            checkNewEnvelopesInContainers(singleton(CRIME_CONTAINER), "Crime");
-        } else {
-            logger.info(
-                "Not checking for new envelopes in {} container because container is disabled", CRIME_CONTAINER
-            );
+        if (isCurrentTimeInBusinessHours(clock)) {
+            if (serviceConfig.getEnabledSourceContainers().contains(CRIME_CONTAINER)) {
+                checkNewEnvelopesInContainers(singleton(CRIME_CONTAINER), "Crime");
+            } else {
+                logger.info(
+                    "Not checking for new envelopes in {} container because container is disabled", CRIME_CONTAINER
+                );
+            }
         }
     }
 
@@ -74,4 +92,9 @@ public class NewEnvelopesFinder {
             .collect(Collectors.toSet());
     }
 
+    private boolean isCurrentTimeInBusinessHours(Clock clock) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        return !WEEKEND.contains(now.getDayOfWeek()) // not weekend
+            && now.getHour() > START_HOUR && now.getHour() < END_HOUR; // between 10am-6pm
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinder.java
@@ -37,7 +37,7 @@ public class NewEnvelopesFinder {
 
     private final Clock clock;
 
-    private static final int START_HOUR = 9;
+    private static final int START_HOUR = 10;
     private static final int END_HOUR = 18;
     private static final List<DayOfWeek> WEEKEND = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
 
@@ -95,6 +95,6 @@ public class NewEnvelopesFinder {
     private boolean isCurrentTimeInBusinessHours(Clock clock) {
         LocalDateTime now = LocalDateTime.now(clock);
         return !WEEKEND.contains(now.getDayOfWeek()) // not weekend
-            && now.getHour() > START_HOUR && now.getHour() < END_HOUR; // between 10am-6pm
+            && now.getHour() >= START_HOUR && now.getHour() <= END_HOUR; // between 10am-6pm
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NewEnvelopesFinderTest.java
@@ -4,12 +4,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import javax.validation.ClockProvider;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -21,8 +28,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 public class NewEnvelopesFinderTest {
 
     @Mock
@@ -31,12 +40,16 @@ public class NewEnvelopesFinderTest {
     @Mock
     private ServiceConfiguration serviceConfiguration;
 
+    @MockBean
+    private ClockProvider clockProvider;
+
     private NewEnvelopesFinder envelopesFinder;
 
     @Test
     void should_check_new_envelopes_in_cft_containers() {
         // given
-        envelopesFinder = new NewEnvelopesFinder(envelopeRepository, serviceConfiguration, Duration.parse("PT10M"));
+        envelopesFinder = newEnvelopeFinderWithBusinessHours();
+
         List<String> containers = asList("c1", "c2", "c3", "crime", "xyz");
         Set<String> cftContainers = Set.of("c1", "c2", "c3", "xyz");
 
@@ -58,7 +71,7 @@ public class NewEnvelopesFinderTest {
     @Test
     void should_check_new_envelopes_in_crime_container_when_crime_is_enabled() {
         // given
-        envelopesFinder = new NewEnvelopesFinder(envelopeRepository, serviceConfiguration, Duration.parse("PT10M"));
+        envelopesFinder = newEnvelopeFinderWithBusinessHours();
         given(serviceConfiguration.getEnabledSourceContainers()).willReturn(singletonList("crime"));
         given(envelopeRepository.getEnvelopesCount(
             eq(singleton("crime")), any(), any()
@@ -75,7 +88,7 @@ public class NewEnvelopesFinderTest {
     @Test
     void should_not_check_new_envelopes_in_crime_container_when_crime_is_not_enabled() {
         // given
-        envelopesFinder = new NewEnvelopesFinder(envelopeRepository, serviceConfiguration, Duration.parse("PT10M"));
+        envelopesFinder = newEnvelopeFinderWithBusinessHours();
         given(serviceConfiguration.getEnabledSourceContainers()).willReturn(asList("c1", "c2"));
 
         // when
@@ -88,9 +101,78 @@ public class NewEnvelopesFinderTest {
 
     @Test
     void should_throw_exception_when_time_interval_is_null() {
-        assertThat(catchThrowable(() -> new NewEnvelopesFinder(envelopeRepository, serviceConfiguration, null)))
-            .isInstanceOf(IllegalArgumentException.class)
+        assertThat(catchThrowable(
+            () -> new NewEnvelopesFinder(envelopeRepository, serviceConfiguration, null, clockProvider))
+        ).isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Time interval is required");
+    }
+
+    @Test
+    void should_not_check_new_envelopes_in_cft_container_before_business_hours() {
+        // given
+        ZonedDateTime dateTime = ZonedDateTime.of(
+            LocalDateTime.of(2020, 3, 10, 8, 0, 0), ZoneId.systemDefault() // before business hours
+        );
+        when(clockProvider.getClock())
+            .thenReturn(Clock.fixed(dateTime.toInstant(), ZoneId.systemDefault()));
+        envelopesFinder = new NewEnvelopesFinder(
+            envelopeRepository, serviceConfiguration, Duration.parse("PT10M"), clockProvider
+        );
+
+        // when
+        envelopesFinder.checkNewCftEnvelopesCreated();
+
+        // then
+        verifyNoInteractions(serviceConfiguration, envelopeRepository);
+    }
+
+    @Test
+    void should_not_check_new_envelopes_in_crime_container_after_business_hours() {
+        // given
+        ZonedDateTime dateTime = ZonedDateTime.of(
+            LocalDateTime.of(2020, 3, 10, 19, 0, 0), ZoneId.systemDefault() // after business hours
+        );
+        when(clockProvider.getClock())
+            .thenReturn(Clock.fixed(dateTime.toInstant(), ZoneId.systemDefault()));
+        envelopesFinder = new NewEnvelopesFinder(
+            envelopeRepository, serviceConfiguration, Duration.parse("PT10M"), clockProvider
+        );
+
+        // when
+        envelopesFinder.checkNewCrimeEnvelopesCreated();
+
+        // then
+        verifyNoInteractions(serviceConfiguration, envelopeRepository);
+    }
+
+    @Test
+    void should_not_check_new_envelopes_in_crime_container_on_weekend() {
+        // given
+        ZonedDateTime dateTime = ZonedDateTime.of(
+            LocalDateTime.of(2020, 3, 8, 11, 0, 0), ZoneId.systemDefault() // weekend (sunday)
+        );
+        when(clockProvider.getClock())
+            .thenReturn(Clock.fixed(dateTime.toInstant(), ZoneId.systemDefault()));
+        envelopesFinder = new NewEnvelopesFinder(
+            envelopeRepository, serviceConfiguration, Duration.parse("PT10M"), clockProvider
+        );
+
+        // when
+        envelopesFinder.checkNewCrimeEnvelopesCreated();
+
+        // then
+        verifyNoInteractions(serviceConfiguration, envelopeRepository);
+    }
+
+    private NewEnvelopesFinder newEnvelopeFinderWithBusinessHours() {
+        ZonedDateTime dateTime = ZonedDateTime.of(
+            LocalDateTime.of(2020, 3, 10, 10, 0, 0), ZoneId.systemDefault() // business hours
+        );
+        when(clockProvider.getClock())
+            .thenReturn(Clock.fixed(dateTime.toInstant(), ZoneId.systemDefault()));
+        return new NewEnvelopesFinder(
+            envelopeRepository, serviceConfiguration, Duration.parse("PT10M"), clockProvider
+        );
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1021

### Change description ###
- Check the database for new envelopes in business hours only.
- Added a bean for `ClockProvider` to inject in the tests and use it to test the business hours and non-business hours scenarios.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
