### PR TITLE
move storage builder to config

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.blobrouter.config;
 
+import com.azure.core.http.HttpClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
@@ -34,9 +36,11 @@ public class StorageConfiguration {
         return mock(BlobContainerClient.class);
     }
 
-    @Bean("bulkscan-storage-client")
-    public BlobContainerClient getBulkScanContainerClient() {
-        return mock(BlobContainerClient.class);
+    @Bean("bulk-scan-blob-client-builder")
+    public BlobContainerClientBuilder getBulkScanBlobContainerClientBuilder() {
+        return new BlobContainerClientBuilder()
+            .httpClient(HttpClient.createDefault())
+            .endpoint("https://example.com");
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/StorageConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.config;
 
+import com.azure.core.http.HttpClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.BlobServiceClient;
@@ -56,5 +57,15 @@ public class StorageConfiguration {
             .connectionString(connectionString)
             .containerName(containerName)
             .buildClient();
+    }
+
+    @Bean("bulk-scan-blob-client-builder")
+    public BlobContainerClientBuilder getBulkScanBlobContainerClientBuilder(
+        HttpClient httpClient,
+        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl
+    ) {
+        return new BlobContainerClientBuilder()
+            .httpClient(httpClient)
+            .endpoint(bulkScanStorageUrl);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProvider.java
@@ -1,10 +1,8 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
-import com.azure.core.http.HttpClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 
@@ -12,29 +10,24 @@ import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 public class BlobContainerClientProvider {
 
     private final BlobContainerClient crimeClient;
-    private final String bulkScanStorageUrl;
-    private final HttpClient httpClient;
+    private final BlobContainerClientBuilder blobContainerClientBuilder;
     private final BulkScanSasTokenCache bulkScanSasTokenCache;
 
     public BlobContainerClientProvider(
         @Qualifier("crime-storage-client") BlobContainerClient crimeClient,
-        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl,
-        HttpClient httpClient,
+        @Qualifier("bulk-scan-blob-client-builder") BlobContainerClientBuilder blobContainerClientBuilder,
         BulkScanSasTokenCache bulkScanSasTokenCache
     ) {
         this.crimeClient = crimeClient;
-        this.bulkScanStorageUrl = bulkScanStorageUrl;
-        this.httpClient = httpClient;
+        this.blobContainerClientBuilder = blobContainerClientBuilder;
         this.bulkScanSasTokenCache = bulkScanSasTokenCache;
     }
 
     public BlobContainerClient get(TargetStorageAccount targetStorageAccount, String containerName) {
         switch (targetStorageAccount) {
             case BULKSCAN:
-                return new BlobContainerClientBuilder()
-                    .httpClient(httpClient)
+                return blobContainerClientBuilder
                     .sasToken(bulkScanSasTokenCache.getSasToken(containerName))
-                    .endpoint(bulkScanStorageUrl)
                     .containerName(containerName)
                     .buildClient();
             case CRIME:

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
-import com.azure.core.http.HttpClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,14 +24,16 @@ public class BlobContainerClientProviderTest {
     @Mock
     private BulkScanSasTokenCache bulkScanSasTokenCache;
 
+    @Mock
+    private BlobContainerClientBuilder blobContainerClientBuilder;
+
     private BlobContainerClientProvider blobContainerClientProvider;
 
     @BeforeEach
     private void setUp() {
         this.blobContainerClientProvider = new BlobContainerClientProvider(
             crimeClient,
-            "https://example.com",
-            HttpClient.createDefault(),
+            blobContainerClientBuilder,
             bulkScanSasTokenCache
         );
     }
@@ -46,6 +49,11 @@ public class BlobContainerClientProviderTest {
     void should_retrieve_sas_token_for_bulk_scan_storage() {
         String containerName = "container123";
         given(bulkScanSasTokenCache.getSasToken(any())).willReturn("token1");
+        given(blobContainerClientBuilder.containerName(containerName)).willReturn(blobContainerClientBuilder);
+        given(blobContainerClientBuilder.sasToken("token1")).willReturn(blobContainerClientBuilder);
+        given(blobContainerClientBuilder.buildClient()).willReturn(mock(BlobContainerClient.class));
+
+
         BlobContainerClient client = blobContainerClientProvider.get(TargetStorageAccount.BULKSCAN, containerName);
 
         assertThat(client).isNotNull();


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1053

### Change description ###

to increase the testability storage client builder moved to config and it is injectable to provider.
next PR I will change provider and dispatcher and move upload function to provider.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
