### PR TITLE
[DO NOT MERGE] Used factory method with user email for green mail user

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
@@ -63,7 +63,6 @@ public class EmailSenderTest {
             Map.of(FILE_NAME_1, file1, FILE_NAME_2, file2)
         );
 
-        assertThat(greenMail.getReceivedMessages()).hasSize(RECIPIENTS.length);
         MimeMessageParser msg = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
         assertThat(msg.getFrom()).isEqualTo(FROM_ADDRESS);
         assertThat(msg.getTo())
@@ -91,7 +90,6 @@ public class EmailSenderTest {
             emptyMap()
         );
 
-        assertThat(greenMail.getReceivedMessages()).hasSize(RECIPIENTS.length);
         MimeMessageParser msg = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
         assertThat(msg.getFrom()).isEqualTo(FROM_ADDRESS);
         assertThat(msg.getTo())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
@@ -42,7 +42,7 @@ public class EmailSenderTest {
 
     @BeforeEach
     void setUp() {
-        greenMail.setUser(USERNAME, PASSWORD);
+        greenMail.setUser(FROM_ADDRESS, USERNAME, PASSWORD);
     }
 
     @Test
@@ -58,8 +58,8 @@ public class EmailSenderTest {
             Map.of(FILE_NAME_1, file1, FILE_NAME_2, file2)
         );
 
+        assertThat(greenMail.getReceivedMessages()).hasSize(RECIPIENTS.length);
         MimeMessageParser msg = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
-
         assertThat(msg.getFrom()).isEqualTo(FROM_ADDRESS);
         assertThat(msg.getTo())
             .extracting(Address::toString)
@@ -86,8 +86,8 @@ public class EmailSenderTest {
             emptyMap()
         );
 
+        assertThat(greenMail.getReceivedMessages()).hasSize(RECIPIENTS.length);
         MimeMessageParser msg = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
-
         assertThat(msg.getFrom()).isEqualTo(FROM_ADDRESS);
         assertThat(msg.getTo())
             .extracting(Address::toString)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/email/EmailSenderTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.services.email;
 
+import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import com.microsoft.applicationinsights.boot.dependencies.google.common.io.Resources;
 import org.apache.commons.mail.util.MimeMessageParser;
@@ -40,9 +41,13 @@ public class EmailSenderTest {
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
+    private GreenMailUser greenMailUser;
+
     @BeforeEach
     void setUp() {
-        greenMail.setUser(FROM_ADDRESS, USERNAME, PASSWORD);
+        if (greenMailUser == null) {
+            greenMailUser = greenMail.setUser(FROM_ADDRESS, USERNAME, PASSWORD);
+        }
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1026


### Change description ###
Integration test is failing inconsistently (and very unfrequently) with this error message:
16:01:33  EmailSenderTest > should_send_email_to_all_recepients() FAILED
16:01:33      org.opentest4j.AssertionFailedError: 
16:01:33      Expecting:
16:01:33       <"test_username">
16:01:33      to be equal to:
16:01:33       <"a@b.c">
16:01:33      but was not.

It looks like GreenMail (which is used for integration tests for sending email) is mixing username and 'from' header. In existing code GreenMailUser is created using factory method with username and password, internally GreenMail uses username as user email, and there is a suspicion that this value is also used for 'from' header instead of the value supposed to be used when email is actually sent (submitted as 'from' parameter of EmailSender::sendMessageWithAttachments method).

In this PR factory method using 3 parameters (user email, username, password) is used; it is expected that in this case when user email (which is the same 'a@b.c' as used later when calling EmailSender::sendMessageWithAttachments) is explicitly submitted to GreenMail username will never be used in 'from' header and the failure will go.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
