### PR TITLE
remove sas token from cache if there is any 40x error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProvider.java
@@ -42,12 +42,12 @@ public class BlobContainerClientProvider {
         }
     }
 
-    public void doUpdate(String blobName,
-                         byte[] blobContents,
-                         String destinationContainer,
-                         TargetStorageAccount targetStorageAccount
+    public void doUpdate(
+        String blobName,
+        byte[] blobContents,
+        String destinationContainer,
+        TargetStorageAccount targetStorageAccount
     ) {
-
         try {
             get(targetStorageAccount, destinationContainer)
                 .getBlobClient(blobName)

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcher.java
@@ -4,8 +4,6 @@ import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 
-import java.io.ByteArrayInputStream;
-
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
@@ -32,14 +30,7 @@ public class BlobDispatcher {
             targetStorageAccount
         );
 
-        blobContainerClientProvider
-            .get(targetStorageAccount, destinationContainer)
-            .getBlobClient(blobName)
-            .getBlockBlobClient()
-            .upload(
-                new ByteArrayInputStream(blobContents),
-                blobContents.length
-            );
+        blobContainerClientProvider.doUpdate(blobName, blobContents, destinationContainer, targetStorageAccount);
 
         logger.info(
             "Finished uploading file. Blob name: {}. Container: {}. Storage: {}",

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
@@ -1,18 +1,28 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.specialized.BlockBlobClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 
+import java.io.ByteArrayInputStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +42,19 @@ public class BlobContainerClientProviderTest {
 
     private BlobContainerClientProvider blobContainerClientProvider;
 
+    @Mock
+    private BlobContainerClient blobContainerClient;
+
+    @Mock
+    private BlobClient blobClient;
+
+    @Mock
+    private BlockBlobClient blockBlobClient;
+
+    final String containerName = "container123";
+    final String blobName = "hello.zip";
+    final byte[] blobContent = "some data".getBytes();
+
     @BeforeEach
     private void setUp() {
         this.blobContainerClientProvider = new BlobContainerClientProvider(
@@ -42,27 +65,109 @@ public class BlobContainerClientProviderTest {
     }
 
     @Test
-    void should_return_crime_client_for_crime_storage() {
-        BlobContainerClient client = blobContainerClientProvider.get(TargetStorageAccount.CRIME, "crime");
+    void should_upload_to_crime_storage_when_target_storage_crime() {
+        given(crimeClient.getBlobClient(blobName)).willReturn(blobClient);
+        given(blobClient.getBlockBlobClient()).willReturn(blockBlobClient);
 
-        assertThat(client).isSameAs(crimeClient);
+        blobContainerClientProvider.doUpdate(
+            blobName,
+            blobContent,
+            containerName,
+            TargetStorageAccount.CRIME);
+
+        // then
+        ArgumentCaptor<ByteArrayInputStream> data = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+
+        verify(blockBlobClient)
+            .upload(
+                data.capture(),
+                eq(Long.valueOf(blobContent.length))
+            );
+
+        assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
+
+        verify(bulkScanSasTokenCache, never()).getSasToken(containerName);
     }
 
     @Test
-    void should_retrieve_sas_token_for_bulk_scan_storage() {
-        String containerName = "container123";
+    void should_upload_to_bulk_scan_storage_when_target_storage_bulk_scan() {
+
         given(bulkScanSasTokenCache.getSasToken(any())).willReturn("token1");
 
         given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
             .willReturn(blobContainerClientBuilder);
         given(blobContainerClientBuilder.containerName(containerName)).willReturn(blobContainerClientBuilder);
         given(blobContainerClientBuilder.sasToken("token1")).willReturn(blobContainerClientBuilder);
-        given(blobContainerClientBuilder.buildClient()).willReturn(mock(BlobContainerClient.class));
+        given(blobContainerClientBuilder.buildClient()).willReturn(blobContainerClient);
+
+        given(blobContainerClient.getBlobClient(blobName)).willReturn(blobClient);
+        given(blobClient.getBlockBlobClient()).willReturn(blockBlobClient);
 
 
-        BlobContainerClient client = blobContainerClientProvider.get(TargetStorageAccount.BULKSCAN, containerName);
+        blobContainerClientProvider.doUpdate(
+            blobName,
+            blobContent,
+            containerName,
+            TargetStorageAccount.BULKSCAN);
 
-        assertThat(client).isNotNull();
         verify(bulkScanSasTokenCache).getSasToken(containerName);
+
+        // then
+        ArgumentCaptor<ByteArrayInputStream> data = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+
+        verify(blockBlobClient)
+            .upload(
+                data.capture(),
+                eq(Long.valueOf(blobContent.length))
+            );
+
+        assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
+
+        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+
+    }
+
+    @Test
+    void should_remove_from_cache_when_target_bulk_scan_and_exception_with_40x_status() {
+
+        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        given(mockHttpResponse.getStatusCode()).willReturn(401);
+
+        given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
+            .willReturn(blobContainerClientBuilder);
+        given(blobContainerClientBuilder.sasToken(any())).willThrow(
+            new BlobStorageException("Sas invalid 401", mockHttpResponse, null));
+
+        assertThatThrownBy(
+            () -> blobContainerClientProvider.doUpdate(
+                blobName,
+                blobContent,
+                containerName,
+                TargetStorageAccount.BULKSCAN
+            )
+        ).isInstanceOf(BlobStorageException.class);
+
+        verify(bulkScanSasTokenCache).removeFromCache(containerName);
+
+    }
+
+    @Test
+    void should_not_remove_from_cache_when_target_crime_even_exception_with_40x_status() {
+
+        HttpResponse mockHttpResponse = mock(HttpResponse.class);
+        given(crimeClient.getBlobClient(any())).willThrow(
+            new BlobStorageException("Sas invalid 401", mockHttpResponse, null));
+
+        assertThatThrownBy(
+            () -> blobContainerClientProvider.doUpdate(
+                blobName,
+                blobContent,
+                containerName,
+                TargetStorageAccount.CRIME
+            )
+        ).isInstanceOf(BlobStorageException.class);
+
+        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProviderTest.java
@@ -128,7 +128,7 @@ public class BlobContainerClientProviderTest {
     }
 
     @Test
-    void should_remove_from_cache_when_target_bulk_scan_and_exception_with_40x_status() {
+    void should_invalidate_cache_when_target_storage_bulk_scan_and_error_response_40x() {
 
         HttpResponse mockHttpResponse = mock(HttpResponse.class);
         given(mockHttpResponse.getStatusCode()).willReturn(401);
@@ -152,7 +152,7 @@ public class BlobContainerClientProviderTest {
     }
 
     @Test
-    void should_not_remove_from_cache_when_target_crime_even_exception_with_40x_status() {
+    void should_not_invalidate_cache_when_target_storage_crime_and_error_response_40x() {
 
         HttpResponse mockHttpResponse = mock(HttpResponse.class);
         given(crimeClient.getBlobClient(any())).willThrow(


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1053

### Change description ###

Remove sas token from cache if there is any 40x error.
update method is moved from Dispatcher to BlobContainerClientProvider.
BlobContainerClientProvider will be renamed to BlobContainerClientProxy (??) next PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
