### PR TITLE
Create `BlobContentExtractor`

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
 import uk.gov.hmcts.reform.blobrouter.data.DbHelper;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
+import uk.gov.hmcts.reform.blobrouter.services.BlobContentExtractor;
 import uk.gov.hmcts.reform.blobrouter.services.BlobVerifier;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProvider;
@@ -48,6 +49,9 @@ class BlobProcessorTest extends BlobStorageBaseTest {
     private LeaseAcquirer leaseAcquirer;
 
     @Autowired
+    private BlobContentExtractor contentExtractor;
+
+    @Autowired
     private DbHelper dbHelper;
 
     @BeforeEach
@@ -74,6 +78,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
                 envelopeService,
                 leaseAcquirer,
                 new BlobVerifier("signing/test_public_key.der"),
+                contentExtractor,
                 serviceConfiguration
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractor.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.blobrouter.services;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
+import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static com.google.common.io.ByteStreams.toByteArray;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
+import static uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers.ENVELOPE;
+
+@Component
+public class BlobContentExtractor {
+
+    public byte[] getContentToUpload(byte[] blobContent, TargetStorageAccount targetAccount) throws IOException {
+        if (targetAccount == CRIME) {
+            try (var zipStream = new ZipInputStream(new ByteArrayInputStream(blobContent))) {
+                ZipEntry entry;
+
+                while ((entry = zipStream.getNextEntry()) != null) {
+                    if (Objects.equals(entry.getName(), ENVELOPE)) {
+                        return toByteArray(zipStream);
+                    }
+                }
+
+                throw new InvalidZipArchiveException(
+                    String.format("ZIP file doesn't contain the required %s entry", ENVELOPE)
+                );
+            }
+        } else {
+           return blobContent;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractor.java
@@ -33,7 +33,7 @@ public class BlobContentExtractor {
                 );
             }
         } else {
-           return blobContent;
+            return blobContent;
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
@@ -71,23 +71,18 @@ class BlobContentExtractorTest {
         assertThat(result).isEqualTo(content);
     }
 
-    private static byte[] getBlobContent(Map<String, byte[]> zipEntries) {
+    private static byte[] getBlobContent(Map<String, byte[]> zipEntries) throws IOException {
         try (
             var outputStream = new ByteArrayOutputStream();
             var zipOutputStream = new ZipOutputStream(outputStream)
         ) {
             for (var entry : zipEntries.entrySet()) {
-                var fileName = entry.getKey();
-                var fileBytes = entry.getValue();
-
-                zipOutputStream.putNextEntry(new ZipEntry(fileName));
-                zipOutputStream.write(fileBytes);
+                zipOutputStream.putNextEntry(new ZipEntry(entry.getKey()));
+                zipOutputStream.write(entry.getValue());
                 zipOutputStream.closeEntry();
             }
 
             return outputStream.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create test blob content", e);
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.blobrouter.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
+import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidZipArchiveException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers.ENVELOPE;
+import static uk.gov.hmcts.reform.blobrouter.util.zipverification.ZipVerifiers.SIGNATURE;
+
+class BlobContentExtractorTest {
+
+    BlobContentExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new BlobContentExtractor();
+    }
+
+    @Test
+    void should_return_internal_zip_for_crime() throws Exception {
+        // given
+        var content = getBlobContent(
+            Map.of(
+                ENVELOPE, "internal".getBytes(),
+                SIGNATURE, "sig".getBytes()
+            )
+        );
+
+        // when
+        var result = extractor.getContentToUpload(content, TargetStorageAccount.CRIME);
+
+        // then
+        assertThat(result).isEqualTo("internal".getBytes());
+    }
+
+    @Test
+    void should_throw_exception_if_internal_zip_for_crime_cannot_be_found() throws Exception {
+        // given
+        var content = getBlobContent(
+            Map.of(
+                "x", "foo".getBytes(),
+                "b", "bar".getBytes()
+            )
+        );
+
+        // when
+        var result = extractor.getContentToUpload(content, TargetStorageAccount.CRIME);
+
+        // then
+        assertThat(result).isEqualTo("internal".getBytes());
+    }
+
+    @Test
+    void should_return_original_zip_for_bulkscan() throws Exception {
+        // given
+        var content = getBlobContent(
+            Map.of(
+                ENVELOPE, "foo".getBytes(),
+                SIGNATURE, "bar".getBytes()
+            )
+        );
+
+        // when
+        var exc = catchThrowable(() -> extractor.getContentToUpload(content, TargetStorageAccount.BULKSCAN));
+
+        // then
+        assertThat(exc).isInstanceOf(InvalidZipArchiveException.class);
+    }
+
+    private static byte[] getBlobContent(Map<String, byte[]> zipEntries) {
+        try (
+            var outputStream = new ByteArrayOutputStream();
+            var zipOutputStream = new ZipOutputStream(outputStream)
+        ) {
+            for (var entry : zipEntries.entrySet()) {
+                var fileName = entry.getKey();
+                var fileBytes = entry.getValue();
+
+                zipOutputStream.putNextEntry(new ZipEntry(fileName));
+                zipOutputStream.write(fileBytes);
+                zipOutputStream.closeEntry();
+            }
+
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test blob content", e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
@@ -53,27 +53,22 @@ class BlobContentExtractorTest {
         );
 
         // when
-        var result = extractor.getContentToUpload(content, TargetStorageAccount.CRIME);
+        var exc = catchThrowable(() -> extractor.getContentToUpload(content, TargetStorageAccount.CRIME));
 
         // then
-        assertThat(result).isEqualTo("internal".getBytes());
+        assertThat(exc).isInstanceOf(InvalidZipArchiveException.class);
     }
 
     @Test
     void should_return_original_zip_for_bulkscan() throws Exception {
         // given
-        var content = getBlobContent(
-            Map.of(
-                ENVELOPE, "foo".getBytes(),
-                SIGNATURE, "bar".getBytes()
-            )
-        );
+        var content = "irrelevant".getBytes();
 
         // when
-        var exc = catchThrowable(() -> extractor.getContentToUpload(content, TargetStorageAccount.BULKSCAN));
+        var result = extractor.getContentToUpload(content, TargetStorageAccount.BULKSCAN);
 
         // then
-        assertThat(exc).isInstanceOf(InvalidZipArchiveException.class);
+        assertThat(result).isEqualTo(content);
     }
 
     private static byte[] getBlobContent(Map<String, byte[]> zipEntries) {


### PR DESCRIPTION
Extracting existing code from `BlobProcessor`.
Mostly to reduce the number of tests required after adding new method `continueProcessingEnvelope(...)` to `BlobProcessor`. (coming soon)