### PR TITLE
find last envelope

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -216,31 +216,33 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_find_envelopes_by_container_and_file_name() {
+    void should_find_last_envelope_by_container_and_file_name() {
         // given
         final String fileName = "foo.bar";
         final String container = "bar";
 
         // and
-        repo.insert(new NewEnvelope(container, fileName, now(), now(), Status.DISPATCHED));
+        repo.insert(new NewEnvelope(container, fileName, now().minusSeconds(99), now(), Status.DISPATCHED));
+        repo.insert(new NewEnvelope(container, fileName, now().minusSeconds(10), null, Status.REJECTED));
 
         // when
-        Optional<Envelope> result = repo.find(fileName, container);
+        Optional<Envelope> result = repo.findLast(fileName, container);
 
         // then
         assertThat(result).hasValueSatisfying(envelope -> {
             assertThat(envelope.fileName).isEqualTo(fileName);
             assertThat(envelope.container).isEqualTo(container);
+            assertThat(envelope.status).isEqualTo(Status.REJECTED);
         });
     }
 
     @Test
-    void should_return_empty_optional_when_envelope_for_given_container_and_file_name_does_not_exist() {
+    void should_return_empty_optional_when_last_envelope_for_given_container_and_file_name_does_not_exist() {
         // given
         repo.insert(new NewEnvelope("a", "b", now(), now(), Status.DISPATCHED));
 
         // when
-        Optional<Envelope> result = repo.find("some_other_file_name", "some_other_container");
+        Optional<Envelope> result = repo.findLast("some_other_file_name", "some_other_container");
 
         // then
         assertThat(result).isEmpty();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/ContainerCleanerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/ContainerCleanerTest.java
@@ -155,8 +155,8 @@ public class ContainerCleanerTest extends BlobStorageBaseTest {
 
     private void assertFilesIsDeleteState(boolean isDeleted, List<String> fileNames) {
         for (String fileName : fileNames) {
-            assertThat(envelopeRepository.find(fileName, CONTAINER_NAME).isPresent()).isTrue();
-            assertThat(envelopeRepository.find(fileName, CONTAINER_NAME).get().isDeleted).isEqualTo(isDeleted);
+            assertThat(envelopeRepository.findLast(fileName, CONTAINER_NAME).isPresent()).isTrue();
+            assertThat(envelopeRepository.findLast(fileName, CONTAINER_NAME).get().isDeleted).isEqualTo(isDeleted);
         }
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -119,7 +119,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
             .as("File should be copied to target container")
             .containsExactly(blobName);
 
-        assertThat(envelopeRepo.find(blobName, sourceContainer))
+        assertThat(envelopeRepo.findLast(blobName, sourceContainer))
             .as("Envelope in the DB has been created")
             .hasValueSatisfying(envelope -> assertThat(envelope.status).isEqualTo(DISPATCHED));
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
@@ -36,25 +36,6 @@ public class EnvelopeRepository {
         }
     }
 
-    public Optional<Envelope> findLast(String fileName, String container) {
-        try {
-            Envelope envelope = jdbcTemplate.queryForObject(
-                "SELECT * FROM envelopes"
-                    + " WHERE file_name = :fileName"
-                    + " AND container = :container"
-                    + " ORDER BY created_at DESC"
-                    + " LIMIT 1",
-                new MapSqlParameterSource()
-                    .addValue("fileName", fileName)
-                    .addValue("container", container),
-                this.mapper
-            );
-            return Optional.of(envelope);
-        } catch (EmptyResultDataAccessException ex) {
-            return Optional.empty();
-        }
-    }
-
     public List<Envelope> find(Status status, String container, boolean isDeleted) {
         return jdbcTemplate.query(
             "SELECT * FROM envelopes WHERE status = :status AND container = :container AND is_deleted = :isDeleted",
@@ -74,6 +55,25 @@ public class EnvelopeRepository {
                 .addValue("isDeleted", isDeleted),
             this.mapper
         );
+    }
+
+    public Optional<Envelope> findLast(String fileName, String container) {
+        try {
+            Envelope envelope = jdbcTemplate.queryForObject(
+                "SELECT * FROM envelopes"
+                    + " WHERE file_name = :fileName"
+                    + " AND container = :container"
+                    + " ORDER BY created_at DESC"
+                    + " LIMIT 1",
+                new MapSqlParameterSource()
+                    .addValue("fileName", fileName)
+                    .addValue("container", container),
+                this.mapper
+            );
+            return Optional.of(envelope);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
     }
 
     public UUID insert(NewEnvelope envelope) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
@@ -36,12 +36,14 @@ public class EnvelopeRepository {
         }
     }
 
-    public Optional<Envelope> find(String fileName, String container) {
+    public Optional<Envelope> findLast(String fileName, String container) {
         try {
             Envelope envelope = jdbcTemplate.queryForObject(
                 "SELECT * FROM envelopes"
                     + " WHERE file_name = :fileName"
-                    + " AND container = :container",
+                    + " AND container = :container"
+                    + " ORDER BY created_at DESC"
+                    + " LIMIT 1",
                 new MapSqlParameterSource()
                     .addValue("fileName", fileName)
                     .addValue("container", container),

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -36,8 +36,8 @@ public class EnvelopeService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Envelope> findEnvelope(String blobName, String containerName) {
-        return envelopeRepository.find(blobName, containerName);
+    public Optional<Envelope> findLastEnvelope(String blobName, String containerName) {
+        return envelopeRepository.findLast(blobName, containerName);
     }
 
     @Transactional(readOnly = true)
@@ -111,7 +111,7 @@ public class EnvelopeService {
 
     @Transactional(readOnly = true)
     public Optional<Tuple2<Envelope, List<EnvelopeEvent>>> getEnvelopeInfo(String blobName, String containerName) {
-        return findEnvelope(blobName, containerName)
+        return findLastEnvelope(blobName, containerName)
             .map(envelope -> Tuples.of(
                 envelope,
                 eventRepository.findForEnvelope(envelope.id)

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -70,7 +70,7 @@ public class ContainerProcessor {
 
     private void processBlob(BlobClient blob) {
         envelopeService
-            .findEnvelope(blob.getBlobName(), blob.getContainerName())
+            .findLastEnvelope(blob.getBlobName(), blob.getContainerName())
             .ifPresentOrElse(
                 envelope -> {
                     if (envelope.status == Status.CREATED) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinder.java
@@ -29,7 +29,7 @@ public class DuplicateFinder {
             .getBlobContainerClient(containerName)
             .listBlobs()
             .stream()
-            .map(blob -> envelopeService.findEnvelope(blob.getName(), containerName))
+            .map(blob -> envelopeService.findLastEnvelope(blob.getName(), containerName))
             .flatMap(Optional::stream)
             .filter(envelope -> envelope.isDeleted) // is deleted -> has already been processed before
             .collect(toList());

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
@@ -75,7 +75,7 @@ public class RejectedContainerCleaner {
         try {
             blobClient.delete();
             envelopeService
-                .findEnvelope(blobName, containerName)
+                .findLastEnvelope(blobName, containerName)
                 .ifPresentOrElse(
                     e -> envelopeService.saveEvent(e.id, EventType.DELETED_FROM_REJECTED),
                     () -> logger.warn("Envelope not found. {}", blobInfo)

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -57,10 +57,10 @@ class EnvelopeServiceTest {
     @Test
     void should_only_call_envelope_repository_to_get_envelope() {
         // when
-        envelopeService.findEnvelope(BLOB_NAME, CONTAINER_NAME);
+        envelopeService.findLastEnvelope(BLOB_NAME, CONTAINER_NAME);
 
         // then
-        verify(envelopeRepository).find(BLOB_NAME, CONTAINER_NAME);
+        verify(envelopeRepository).findLast(BLOB_NAME, CONTAINER_NAME);
         verifyNoInteractions(eventRepository);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -86,7 +86,7 @@ class ContainerProcessorTest {
     void should_process_blob_if_envelope_does_not_exist_yet() {
         // given
         storageHasBlob("x.zip", "container");
-        given(envelopeService.findEnvelope(any(), any())).willReturn(Optional.empty());
+        given(envelopeService.findLastEnvelope(any(), any())).willReturn(Optional.empty());
 
         // when
         containerProcessor.process("container");
@@ -109,7 +109,7 @@ class ContainerProcessorTest {
     }
 
     private void dbHas(Envelope envelope) {
-        given(envelopeService.findEnvelope(envelope.fileName, envelope.container))
+        given(envelopeService.findLastEnvelope(envelope.fileName, envelope.container))
             .willReturn(Optional.of(envelope));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/DuplicateFinderTest.java
@@ -49,9 +49,9 @@ class DuplicateFinderTest {
                 blob("c.zip")
             ));
 
-        given(envelopeService.findEnvelope("a.zip", "container")).willReturn(Optional.empty());
-        given(envelopeService.findEnvelope("b.zip", "container")).willReturn(Optional.of(deletedEnvelope));
-        given(envelopeService.findEnvelope("c.zip", "container")).willReturn(Optional.of(notYetDeletedEnvelope));
+        given(envelopeService.findLastEnvelope("a.zip", "container")).willReturn(Optional.empty());
+        given(envelopeService.findLastEnvelope("b.zip", "container")).willReturn(Optional.of(deletedEnvelope));
+        given(envelopeService.findLastEnvelope("c.zip", "container")).willReturn(Optional.of(notYetDeletedEnvelope));
 
         // when
         List<Envelope> result = new DuplicateFinder(storageClient, envelopeService).findIn("container");

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleanerTest.java
@@ -106,7 +106,7 @@ class RejectedContainerCleanerTest {
         given(blobClient2.getBlobName()).willReturn(REJECTED_BLOB);
 
         var envelopeId = UUID.randomUUID();
-        given(envelopeService.findEnvelope(REJECTED_BLOB, REJECTED_CONTAINER))
+        given(envelopeService.findLastEnvelope(REJECTED_BLOB, REJECTED_CONTAINER))
             .willReturn(Optional.of(new Envelope(envelopeId, null, null, null, null, null, null, true)));
 
         // when


### PR DESCRIPTION
Changing the existing method for finding envelope by filename and container to return the last envelope.

In preparation for adding duplicates as new envelopes
(although, constraint has already beem removed in #295)


https://tools.hmcts.net/jira/browse/BPS-1065

