### PR TITLE
Clean up mock declaration in tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -38,31 +38,17 @@ import static uk.gov.hmcts.reform.blobrouter.testutils.DirectoryZipper.zipAndSig
 @ExtendWith(MockitoExtension.class)
 class BlobProcessorTest extends BlobStorageBaseTest {
 
-    private BlobContainerClientProxy containerClientProvider;
+    BlobContainerClientProxy containerClientProvider;
 
-    @Mock
-    private BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
+    @Mock BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
+    @Mock BlobContainerClientBuilder blobContainerClientBuilder;
 
-    @Mock
-    private BlobContainerClientBuilder blobContainerClientBuilder;
-
-    @Autowired
-    private EnvelopeService envelopeService;
-
-    @Autowired
-    private EnvelopeRepository envelopeRepo;
-
-    @Autowired
-    private ServiceConfiguration serviceConfiguration;
-
-    @Autowired
-    private LeaseAcquirer leaseAcquirer;
-
-    @Autowired
-    private BlobContentExtractor contentExtractor;
-
-    @Autowired
-    private DbHelper dbHelper;
+    @Autowired EnvelopeService envelopeService;
+    @Autowired EnvelopeRepository envelopeRepo;
+    @Autowired ServiceConfiguration serviceConfiguration;
+    @Autowired LeaseAcquirer leaseAcquirer;
+    @Autowired BlobContentExtractor contentExtractor;
+    @Autowired DbHelper dbHelper;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
@@ -28,28 +28,16 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class BlobContainerClientProxyTest {
 
-    @Mock
-    private BlobContainerClient crimeClient;
+    @Mock BlobContainerClient crimeClient;
+    @Mock BulkScanSasTokenCache bulkScanSasTokenCache;
+    @Mock BlobContainerClientBuilder blobContainerClientBuilder;
+    @Mock BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
 
-    @Mock
-    private BulkScanSasTokenCache bulkScanSasTokenCache;
+    BlobContainerClientProxy blobContainerClientProxy;
 
-    @Mock
-    private BlobContainerClientBuilder blobContainerClientBuilder;
-
-    @Mock
-    private BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
-
-    private BlobContainerClientProxy blobContainerClientProxy;
-
-    @Mock
-    private BlobContainerClient blobContainerClient;
-
-    @Mock
-    private BlobClient blobClient;
-
-    @Mock
-    private BlockBlobClient blockBlobClient;
+    @Mock BlobContainerClient blobContainerClient;
+    @Mock BlobClient blobClient;
+    @Mock BlockBlobClient blockBlobClient;
 
     final String containerName = "container123";
     final String blobName = "hello.zip";

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
@@ -36,20 +36,11 @@ class ContainerCleanerTest {
 
     private ContainerCleaner containerCleaner;
 
-    @Mock
-    private EnvelopeService envelopeService;
-
-    @Mock
-    private BlobServiceClient storageClient;
-
-    @Mock
-    private BlobContainerClient containerClient;
-
-    @Mock
-    private BlobClient blobClient1;
-
-    @Mock
-    private BlobClient blobClient2;
+    @Mock EnvelopeService envelopeService;
+    @Mock BlobServiceClient storageClient;
+    @Mock BlobContainerClient containerClient;
+    @Mock BlobClient blobClient1;
+    @Mock BlobClient blobClient2;
 
     private static final Envelope ENVELOPE_1 = createEnvelope(UUID.randomUUID(), DISPATCHED, "file1.zip");
     private static final Envelope ENVELOPE_2 = createEnvelope(UUID.randomUUID(), DISPATCHED, "file2.zip");


### PR DESCRIPTION
 putting annotation in the same line.

- saves screen space
- makes it easier to see what's a mock and what is not