### PR TITLE
Acquire lease before deciding what to do with blob

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientBuilde
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProxy;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BulkScanSasTokenCache;
-import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.io.ByteArrayInputStream;
@@ -47,7 +46,6 @@ class BlobProcessorTest extends BlobStorageBaseTest {
     @Autowired EnvelopeService envelopeService;
     @Autowired EnvelopeRepository envelopeRepo;
     @Autowired ServiceConfiguration serviceConfiguration;
-    @Autowired LeaseAcquirer leaseAcquirer;
     @Autowired BlobContentExtractor contentExtractor;
     @Autowired DbHelper dbHelper;
 
@@ -98,7 +96,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
             .upload(new ByteArrayInputStream(bytes), bytes.length);
 
         // when
-        blobProcessor.process(blobClient, leaseAcquirer.acquireFor(blobClient).get());
+        blobProcessor.process(blobClient);
 
         // then
         assertThat(targetContainerClient.listBlobs())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -77,7 +77,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
 
         // then
         var blobArgCaptor = ArgumentCaptor.forClass(BlobClient.class);
-        verify(blobProcessor, times(2)).process(blobArgCaptor.capture(), any());
+        verify(blobProcessor, times(2)).process(blobArgCaptor.capture());
 
         assertThat(blobArgCaptor.getAllValues())
             .extracting(BlobClientBase::getBlobName)
@@ -95,7 +95,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
         containerProcessor.process(CONTAINER_NAME);
 
         // then
-        verify(blobProcessor, never()).process(any(), any());
+        verify(blobProcessor, never()).process(any());
     }
 
     void upload(BlobContainerClient containerClient, String fileName) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.blobrouter.data.DbHelper;
 import uk.gov.hmcts.reform.blobrouter.services.BlobReadinessChecker;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
+import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.time.Instant;
@@ -35,6 +36,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
     private static final String CONTAINER_NAME = "my-container";
 
     @Autowired EnvelopeService envelopeService;
+    @Autowired LeaseAcquirer leaseAcquirer;
     @Autowired DbHelper dbHelper;
 
     @Mock BlobProcessor blobProcessor;
@@ -49,6 +51,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
             storageClient,
             blobProcessor,
             blobReadinessChecker,
+            leaseAcquirer,
             envelopeService
         );
         containerClient = createContainer(CONTAINER_NAME);
@@ -74,7 +77,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
 
         // then
         var blobArgCaptor = ArgumentCaptor.forClass(BlobClient.class);
-        verify(blobProcessor, times(2)).process(blobArgCaptor.capture());
+        verify(blobProcessor, times(2)).process(blobArgCaptor.capture(), any());
 
         assertThat(blobArgCaptor.getAllValues())
             .extracting(BlobClientBase::getBlobName)
@@ -92,7 +95,7 @@ class ContainerProcessorTest extends BlobStorageBaseTest {
         containerProcessor.process(CONTAINER_NAME);
 
         // then
-        verify(blobProcessor, never()).process(any());
+        verify(blobProcessor, never()).process(any(), any());
     }
 
     void upload(BlobContainerClient containerClient, String fileName) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobStorageException;
-import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessor.java
@@ -88,9 +88,9 @@ public class BlobProcessor {
     private void handle(
         BlobClient blobClient,
         Supplier<UUID> envelopeIdSupplier,
-        Condition postLeaseCondition
+        Condition processingCondition
     ) {
-        if (postLeaseCondition.isMet()) {
+        if (processingCondition.isMet()) {
             UUID id = envelopeIdSupplier.get();
             try {
                 byte[] rawBlob = downloadBlob(blobClient);
@@ -108,7 +108,7 @@ public class BlobProcessor {
         } else {
             logger.info(
                 "Skipping file: {}. File name: {}, container: {}",
-                postLeaseCondition.getMessage(),
+                processingCondition.getMessage(),
                 blobClient.getBlobName(),
                 blobClient.getContainerName()
             );

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorContinuationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorContinuationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +42,6 @@ public class BlobProcessorContinuationTest {
     @Mock BlobVerifier verifier;
     @Mock BlobContentExtractor contentExtractor;
     @Mock ServiceConfiguration serviceConfiguration;
-    @Mock BlobLeaseClient blobLeaseClient;
     @Mock(lenient = true) BlobClient blobClient;
 
     BlobProcessor blobProcessor;
@@ -78,7 +76,7 @@ public class BlobProcessorContinuationTest {
         given(contentExtractor.getContentToUpload(any(), any())).willReturn(content);
 
         // when
-        blobProcessor.continueProcessing(id, blobClient, blobLeaseClient);
+        blobProcessor.continueProcessing(id, blobClient);
 
         // then
         verify(envelopeService).findEnvelope(id);
@@ -98,7 +96,7 @@ public class BlobProcessorContinuationTest {
         given(verifier.verifyZip(any(), any())).willReturn(error(validationError));
 
         // when
-        blobProcessor.continueProcessing(id, blobClient, blobLeaseClient);
+        blobProcessor.continueProcessing(id, blobClient);
 
         // then
         verify(envelopeService).findEnvelope(id);
@@ -116,7 +114,7 @@ public class BlobProcessorContinuationTest {
         given(envelopeService.findEnvelope(id)).willReturn(Optional.of(envelope(id, Status.DISPATCHED)));
 
         // when
-        blobProcessor.continueProcessing(id, blobClient, blobLeaseClient);
+        blobProcessor.continueProcessing(id, blobClient);
 
         // then
         verify(envelopeService).findEnvelope(id);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -4,7 +4,6 @@ import com.azure.core.http.HttpResponse;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobStorageException;
-import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -49,7 +48,6 @@ class BlobProcessorTest {
     @Mock(lenient = true) BlobClient blobClient;
     @Mock(lenient = true) BlobProperties blobProperties;
     @Mock BlobDispatcher blobDispatcher;
-    @Mock BlobLeaseClient blobLeaseClient;
     @Mock EnvelopeService envelopeService;
     @Mock BlobVerifier verifier;
     @Mock ServiceConfiguration serviceConfiguration;
@@ -69,7 +67,7 @@ class BlobProcessorTest {
             .dispatch(any(), any(), any(), any());
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verifyNewEnvelopeHasBeenCreated();
@@ -100,7 +98,7 @@ class BlobProcessorTest {
             .download(any());
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verifyNewEnvelopeHasBeenCreated();
@@ -125,7 +123,7 @@ class BlobProcessorTest {
         willThrow(new RuntimeException("test")).given(blobClient).download(any());
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verifyNewEnvelopeHasBeenCreated();
@@ -153,7 +151,7 @@ class BlobProcessorTest {
         given(verifier.verifyZip(any(), any())).willReturn(ok());
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verify(blobDispatcher, times(1)).dispatch(any(), any(), any(), any());
@@ -176,7 +174,7 @@ class BlobProcessorTest {
         given(verifier.verifyZip(any(), any())).willReturn(error("some error"));
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verifyNoInteractions(blobDispatcher);
@@ -203,7 +201,7 @@ class BlobProcessorTest {
         given(verifier.verifyZip(any(), any())).willReturn(ok());
 
         // when
-        newBlobProcessor().process(blobClient, blobLeaseClient);
+        newBlobProcessor().process(blobClient);
 
         // then
         verifyNewEnvelopeHasBeenCreated();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -90,6 +90,20 @@ class ContainerProcessorTest {
     }
 
     @Test
+    void should_skip_blob_if_lease_cannot_be_acquired() {
+        // given
+        var envelope = envelope(Status.CREATED);
+        storageHasBlob(envelope.fileName, envelope.container);
+        leaseCannotBeAcquired();
+
+        // when
+        containerProcessor.process(envelope.container);
+
+        // then
+        verifyNoInteractions(blobProcessor);
+    }
+
+    @Test
     void should_process_blob_if_envelope_does_not_exist_yet() {
         // given
         storageHasBlob("x.zip", "container");
@@ -123,6 +137,10 @@ class ContainerProcessorTest {
 
     private void leaseCanBeAcquired() {
         given(leaseAcquirer.acquireFor(blobClient)).willReturn(Optional.of(leaseClient));
+    }
+
+    private void leaseCannotBeAcquired() {
+        given(leaseAcquirer.acquireFor(blobClient)).willReturn(Optional.empty());
     }
 
     private Envelope envelope(Status status) {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -70,7 +70,7 @@ class ContainerProcessorTest {
         containerProcessor.process(envelope.container);
 
         // then
-        verify(blobProcessor).continueProcessing(envelope.id, blobClient, leaseClient);
+        verify(blobProcessor).continueProcessing(envelope.id, blobClient);
         verifyNoMoreInteractions(blobProcessor);
     }
 
@@ -100,7 +100,7 @@ class ContainerProcessorTest {
         containerProcessor.process("container");
 
         // then
-        verify(blobProcessor).process(blobClient, leaseClient);
+        verify(blobProcessor).process(blobClient);
         verifyNoMoreInteractions(blobProcessor);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -6,6 +6,7 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobItemProperties;
+import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 import uk.gov.hmcts.reform.blobrouter.services.BlobReadinessChecker;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
+import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -35,10 +37,12 @@ class ContainerProcessorTest {
     @Mock BlobServiceClient storageClient;
     @Mock BlobProcessor blobProcessor;
     @Mock BlobReadinessChecker blobReadinessChecker;
+    @Mock LeaseAcquirer leaseAcquirer;
     @Mock EnvelopeService envelopeService;
 
     @Mock BlobContainerClient containerClient;
     @Mock BlobClient blobClient;
+    @Mock BlobLeaseClient leaseClient;
     @Mock PagedIterable<BlobItem> listBlobsResult;
 
     ContainerProcessor containerProcessor;
@@ -49,6 +53,7 @@ class ContainerProcessorTest {
             storageClient,
             blobProcessor,
             blobReadinessChecker,
+            leaseAcquirer,
             envelopeService
         );
     }
@@ -58,13 +63,14 @@ class ContainerProcessorTest {
         // given
         var envelope = envelope(Status.CREATED);
         storageHasBlob(envelope.fileName, envelope.container);
+        leaseCanBeAcquired();
         dbHas(envelope);
 
         // when
         containerProcessor.process(envelope.container);
 
         // then
-        verify(blobProcessor).continueProcessing(envelope.id, blobClient);
+        verify(blobProcessor).continueProcessing(envelope.id, blobClient, leaseClient);
         verifyNoMoreInteractions(blobProcessor);
     }
 
@@ -73,6 +79,7 @@ class ContainerProcessorTest {
         // given
         var envelope = envelope(Status.DISPATCHED);
         storageHasBlob(envelope.fileName, envelope.container);
+        leaseCanBeAcquired();
         dbHas(envelope);
 
         // when
@@ -86,13 +93,14 @@ class ContainerProcessorTest {
     void should_process_blob_if_envelope_does_not_exist_yet() {
         // given
         storageHasBlob("x.zip", "container");
+        leaseCanBeAcquired();
         given(envelopeService.findLastEnvelope(any(), any())).willReturn(Optional.empty());
 
         // when
         containerProcessor.process("container");
 
         // then
-        verify(blobProcessor).process(blobClient);
+        verify(blobProcessor).process(blobClient, leaseClient);
         verifyNoMoreInteractions(blobProcessor);
     }
 
@@ -111,6 +119,10 @@ class ContainerProcessorTest {
     private void dbHas(Envelope envelope) {
         given(envelopeService.findLastEnvelope(envelope.fileName, envelope.container))
             .willReturn(Optional.of(envelope));
+    }
+
+    private void leaseCanBeAcquired() {
+        given(leaseAcquirer.acquireFor(blobClient)).willReturn(Optional.of(leaseClient));
     }
 
     private Envelope envelope(Status status) {


### PR DESCRIPTION
To handle scenarios when multiple instances of blob router are 'competing' for the same file.
