### PR TITLE
Add pending notifications field to the envelope info response

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -82,6 +82,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(1)))
             .andExpect(jsonPath("$.data[0].id").value(envelopeInDb.id.toString()))
+            .andExpect(jsonPath("$.data[0].pending_notification").value(envelopeInDb.pendingNotification))
             .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
                 EventType.FILE_PROCESSING_STARTED.name(),
                 EventType.DISPATCHED.name()

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
@@ -51,6 +51,7 @@ public class EnvelopeController {
             dbEnvelope.dispatchedAt,
             dbEnvelope.status,
             dbEnvelope.isDeleted,
+            dbEnvelope.pendingNotification,
             dbEventRecords
                 .stream()
                 .map(e -> new EnvelopeEventResponse(e.id, e.createdAt, e.type.name(), e.notes))

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeInfo.java
@@ -33,6 +33,9 @@ public class EnvelopeInfo {
     @JsonProperty("is_deleted")
     public final boolean isDeleted;
 
+    @JsonProperty("pending_notification")
+    public final boolean pendingNotification;
+
     @JsonProperty("events")
     public final List<EnvelopeEventResponse> envelopeEvents;
 
@@ -45,6 +48,7 @@ public class EnvelopeInfo {
         Instant dispatchedAt,
         Status status,
         boolean isDeleted,
+        boolean pendingNotification,
         List<EnvelopeEventResponse> envelopeEvents
     ) {
         this.id = id;
@@ -55,6 +59,7 @@ public class EnvelopeInfo {
         this.dispatchedAt = dispatchedAt;
         this.status = status;
         this.isDeleted = isDeleted;
+        this.pendingNotification = pendingNotification;
         this.envelopeEvents = envelopeEvents;
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1096

### Change description ###
Add pending notifications field to the `EnvelopeInfo` response in the `/envelopes`endpoint.
This is required for the functional test.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
