### PR TITLE
Update error_code field type in the notification queue message

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelope.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope;
 
+import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
+
 import java.util.UUID;
 
 public class RejectedEnvelope {
@@ -7,17 +9,20 @@ public class RejectedEnvelope {
     public final UUID envelopeId;
     public final String container;
     public final String fileName;
+    public final ErrorCode errorCode;
     public final String errorDescription;
 
     public RejectedEnvelope(
         UUID envelopeId,
         String container,
         String fileName,
+        ErrorCode errorCode,
         String errorDescription
     ) {
         this.envelopeId = envelopeId;
         this.container = container;
         this.fileName = fileName;
+        this.errorCode = errorCode;
         this.errorDescription = errorDescription;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelopeMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelopeMapper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope;
 
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -16,6 +17,7 @@ public class RejectedEnvelopeMapper implements RowMapper<RejectedEnvelope> {
             UUID.fromString(rs.getString("id")),
             rs.getString("container"),
             rs.getString("file_name"),
+            rs.getString("error_code") != null ? ErrorCode.valueOf(rs.getString("error_code")) : null,
             rs.getString("errorDescription")
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/rejectedenvelope/RejectedEnvelopeRepository.java
@@ -21,7 +21,7 @@ public class RejectedEnvelopeRepository {
 
     public List<RejectedEnvelope> getRejectedEnvelopes() {
         return jdbcTemplate.query(
-            "SELECT env.id, env.file_name, env.container, event.notes as errorDescription "
+            "SELECT env.id, env.file_name, env.container, event.error_code, event.notes as errorDescription "
                 + " FROM envelopes env, envelope_events event "
                 + " WHERE env.id = event.envelope_id "
                 + "     AND event.type = 'REJECTED' "

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/model/NotificationMsg.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/model/NotificationMsg.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.servicebus.notifications.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
 
 public class NotificationMsg {
 
@@ -14,7 +15,7 @@ public class NotificationMsg {
     public final String documentControlNumber;
 
     @JsonProperty("error_code")
-    public final String errorCode;
+    public final ErrorCode errorCode;
 
     @JsonProperty("error_description")
     public final String errorDescription;
@@ -26,7 +27,7 @@ public class NotificationMsg {
         String zipFileName,
         String container,
         String documentControlNumber,
-        String errorCode,
+        ErrorCode errorCode,
         String errorDescription,
         String service
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NotificationService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.blobrouter.services;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 import uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope.RejectedEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope.RejectedEnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.servicebus.notifications.NotificationsPublisher;
@@ -52,7 +51,7 @@ public class NotificationService {
             envelope.fileName,
             envelope.container,
             null,
-            EventType.REJECTED.name(),
+            envelope.errorCode,
             envelope.errorDescription,
             SERVICE_NAME
         );

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisherTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.util.CollectionUtils;
+import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
 import uk.gov.hmcts.reform.blobrouter.servicebus.notifications.model.NotificationMsg;
 
 import java.util.List;
@@ -44,7 +45,7 @@ class NotificationsPublisherTest {
             "test.zip",
             "C1",
             "1234",
-            "Invalid Signature",
+            ErrorCode.ERR_SIG_VERIFY_FAILED,
             "Signature verification failed",
             "blob-router"
         );

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
 import uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope.RejectedEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.rejectedenvelope.RejectedEnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.servicebus.notifications.NotificationsPublisher;
@@ -46,8 +47,8 @@ class NotificationServiceTest {
         UUID envelopeId2 = UUID.randomUUID();
         given(rejectedEnvelopeRepository.getRejectedEnvelopes()).willReturn(
             asList(
-                new RejectedEnvelope(envelopeId1, "c1", "test1.zip", "notes1"),
-                new RejectedEnvelope(envelopeId2, "c2", "test2.zip", "notes1")
+                new RejectedEnvelope(envelopeId1, "c1", "test1.zip", ErrorCode.ERR_ZIP_PROCESSING_FAILED, "notes1"),
+                new RejectedEnvelope(envelopeId2, "c2", "test2.zip", ErrorCode.ERR_AV_FAILED, "notes1")
             )
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1096


### Change description ###
- Update reject envelopes query to get `error_code` from `envelope_events`
- Update error_code field type from String to `ErrorCode` enum


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
