### PR TITLE
Dont log error when blob was already deleted

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -7,6 +7,8 @@ import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
+import static com.azure.storage.blob.models.BlobErrorCode.BLOB_NOT_FOUND;
+import static com.azure.storage.blob.models.BlobErrorCode.LEASE_ALREADY_PRESENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
@@ -31,7 +33,7 @@ public class LeaseAcquirer {
             release(leaseClient, blobClient);
 
         } catch (BlobStorageException exc) {
-            if (exc.getErrorCode() != BlobErrorCode.LEASE_ALREADY_PRESENT) {
+            if (exc.getErrorCode() != LEASE_ALREADY_PRESENT && exc.getErrorCode() != BLOB_NOT_FOUND) {
                 logger.error(
                     "Error acquiring lease for blob. File name: {}, Container: {}",
                     blobClient.getBlobName(),

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.slf4j.Logger;


### PR DESCRIPTION
The main job is not using schedlock, locks on files are used instead.
Currently, when a job tries to acquire a lease for a file that is already being process it just silently skips it.

Adding the same logic for when blob was already deleted.