### PR TITLE
Disabled Mail health check as it causes readiness probe to fail

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ management:
   endpoints:
     web:
       base-path: /
+  health:
+    mail:
+      enabled: false
 
 spring:
   application:


### PR DESCRIPTION
### Change description ###

- We are getting lots of errors on prod due to readiness probe failures.

- After checking logs issue is health check fails due to failure to connect to mail server and this happens due to `UnknownHostException` which is probably due to DNS issues.

- Spring boot mail health is enabled by default , hence disabling it as application health need not rely on it and we get loads of false positives which then seems to be application not coming up with current readiness/liveness probe settings.

- We may revert this change once DNS is stable.

```
Inner exception java.net.UnknownHostException handled at com.sun.mail.smtp.SMTPTransport.openServer:

````
```
com.sun.mail.util.MailConnectException:
   at com.sun.mail.smtp.SMTPTransport.openServer (SMTPTransport.java2210)
   at com.sun.mail.smtp.SMTPTransport.protocolConnect (SMTPTransport.java722)
   at javax.mail.Service.connect (Service.java342)
   at org.springframework.mail.javamail.JavaMailSenderImpl.connectTransport (JavaMailSenderImpl.java518)
   at org.springframework.mail.javamail.JavaMailSenderImpl.testConnection (JavaMailSenderImpl.java398)
   at org.springframework.boot.actuate.mail.MailHealthIndicator.doHealthCheck (MailHealthIndicator.java42)
   at org.springframework.boot.actuate.health.AbstractHealthIndicator.health (AbstractHealthIndicator.java82)
   at org.springframework.boot.actuate.health.HealthIndicator.getHealth (HealthIndicator.java37)
```
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
