### PR TITLE
Update envelope service method to return envelope events

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.data;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,8 +56,8 @@ public class EnvelopeEventRepositoryTest {
             .hasSize(2)
             .usingElementComparatorIgnoringFields("createdAt")
             .containsExactlyInAnyOrder(
-                new EnvelopeEvent(eventId1, envelopeId, event1.type, event1.errorCode, event1.notes, now()),
-                new EnvelopeEvent(eventId2, envelopeId, event2.type, event2.errorCode, event2.notes, now())
+                envelopeEvent(envelopeId, event1, eventId1),
+                envelopeEvent(envelopeId, event2, eventId2)
             );
 
         assertThat(eventsInDb.get(0).createdAt).isNotNull();
@@ -104,9 +105,9 @@ public class EnvelopeEventRepositoryTest {
             .hasSize(3)
             .usingElementComparatorIgnoringFields("createdAt")
             .containsExactly(
-                new EnvelopeEvent(eventId2b, envelopeId2, event2b.type, event2b.errorCode, event2b.notes, now()),
-                new EnvelopeEvent(eventId2a, envelopeId2, event2a.type, event2a.errorCode, event2a.notes, now()),
-                new EnvelopeEvent(eventId1a, envelopeId1, event1a.type, event1a.errorCode, event1a.notes, now())
+                envelopeEvent(envelopeId2, event2b, eventId2b),
+                envelopeEvent(envelopeId2, event2a, eventId2a),
+                envelopeEvent(envelopeId1, event1a, eventId1a)
             );
     }
 
@@ -121,6 +122,11 @@ public class EnvelopeEventRepositoryTest {
 
         // then
         assertThat(eventsInDb).isEmpty();
+    }
+
+    @NotNull
+    private EnvelopeEvent envelopeEvent(UUID envelopeId, NewEnvelopeEvent event, long eventId) {
+        return new EnvelopeEvent(eventId, envelopeId, event.type, event.errorCode, event.notes, now());
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.EnvelopeRepository;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.NewEnvelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
+import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEventRepository;
 import uk.gov.hmcts.reform.blobrouter.data.events.ErrorCode;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
@@ -20,7 +21,6 @@ import static java.time.Instant.now;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.tuple;
 
 @ActiveProfiles({"integration-test", "db-test"})
 @SpringBootTest
@@ -53,10 +53,10 @@ public class EnvelopeEventRepositoryTest {
         // then
         assertThat(eventsInDb)
             .hasSize(2)
-            .extracting(e -> tuple(e.id, e.envelopeId, e.type, e.errorCode, e.notes))
+            .usingElementComparatorIgnoringFields("createdAt")
             .containsExactlyInAnyOrder(
-                tuple(eventId1, envelopeId, event1.type, event1.errorCode, event1.notes),
-                tuple(eventId2, envelopeId, event2.type, event2.errorCode, event2.notes)
+                new EnvelopeEvent(eventId1, envelopeId, event1.type, event1.errorCode, event1.notes, now()),
+                new EnvelopeEvent(eventId2, envelopeId, event2.type, event2.errorCode, event2.notes, now())
             );
 
         assertThat(eventsInDb.get(0).createdAt).isNotNull();
@@ -102,11 +102,11 @@ public class EnvelopeEventRepositoryTest {
         // then
         assertThat(eventsInDb)
             .hasSize(3)
-            .extracting(e -> tuple(e.id, e.envelopeId, e.type, e.errorCode, e.notes))
+            .usingElementComparatorIgnoringFields("createdAt")
             .containsExactly(
-                tuple(eventId2b, envelopeId2, event2b.type, event2b.errorCode, event2b.notes),
-                tuple(eventId2a, envelopeId2, event2a.type, event2a.errorCode, event2a.notes),
-                tuple(eventId1a, envelopeId1, event1a.type, event1a.errorCode, event1a.notes)
+                new EnvelopeEvent(eventId2b, envelopeId2, event2b.type, event2b.errorCode, event2b.notes, now()),
+                new EnvelopeEvent(eventId2a, envelopeId2, event2a.type, event2a.errorCode, event2a.notes, now()),
+                new EnvelopeEvent(eventId1a, envelopeId1, event1a.type, event1a.errorCode, event1a.notes, now())
             );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -331,15 +331,16 @@ public class EnvelopeRepositoryTest {
     @Test
     void should_return_envelopes_for_the_requested_date() {
         //given
-        addEnvelope("C1", "f1");
-        addEnvelope("C3", "f2");
-        addEnvelope("C3", "f3");
+        UUID id1 = addEnvelope("f1", "C1");
+        UUID id2 = addEnvelope("f2", "C2");
+        UUID id3 = addEnvelope("f3", "C2");
 
         // when
         List<Envelope> envelopes = repo.findEnvelopes(null, null, LocalDate.now());
 
         // then
         assertThat(envelopes).isNotEmpty().hasSize(3);
+        assertThat(envelopes).extracting(env -> env.id).containsExactly(id3, id2, id1); // ordered by created_at
     }
 
     @Test
@@ -377,15 +378,16 @@ public class EnvelopeRepositoryTest {
     @Test
     void should_return_all_envelopes_when_all_params_are_null() {
         //given
-        addEnvelope("f1", "C1");
-        addEnvelope("f2", "C2");
-        addEnvelope("f3", "C2");
+        UUID id1 = addEnvelope("f1", "C1");
+        UUID id2 = addEnvelope("f2", "C2");
+        UUID id3 = addEnvelope("f3", "C2");
 
         // when
         List<Envelope> envelopes = repo.findEnvelopes(null, null, null);
 
         // then
         assertThat(envelopes).isNotEmpty().hasSize(3);
+        assertThat(envelopes).extracting(env -> env.id).containsExactly(id3, id2, id1); // ordered by created_at
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles({"integration-test", "db-test"})
 @SpringBootTest
+@SuppressWarnings("checkstyle:variabledeclarationusagedistance")
 public class EnvelopeRepositoryTest {
 
     @Autowired private EnvelopeRepository repo;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles({"integration-test", "db-test"})
 @SpringBootTest
-@SuppressWarnings("checkstyle:variabledeclarationusagedistance")
 public class EnvelopeRepositoryTest {
 
     @Autowired private EnvelopeRepository repo;
@@ -330,12 +329,10 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_return_envelopes_for_the_requested_date() throws Exception {
+    void should_return_envelopes_for_the_requested_date() {
         //given
         UUID id1 = addEnvelope("f1", "C1");
-        Thread.sleep(1);
         UUID id2 = addEnvelope("f2", "C2");
-        Thread.sleep(1);
         UUID id3 = addEnvelope("f3", "C2");
 
         // when
@@ -379,12 +376,10 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_return_all_envelopes_when_all_params_are_null() throws Exception {
+    void should_return_all_envelopes_when_all_params_are_null() {
         //given
         UUID id1 = addEnvelope("f1", "C1");
-        Thread.sleep(1);
         UUID id2 = addEnvelope("f2", "C2");
-        Thread.sleep(1);
         UUID id3 = addEnvelope("f3", "C2");
 
         // when

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeRepositoryTest.java
@@ -329,10 +329,12 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_return_envelopes_for_the_requested_date() {
+    void should_return_envelopes_for_the_requested_date() throws Exception {
         //given
         UUID id1 = addEnvelope("f1", "C1");
+        Thread.sleep(1);
         UUID id2 = addEnvelope("f2", "C2");
+        Thread.sleep(1);
         UUID id3 = addEnvelope("f3", "C2");
 
         // when
@@ -376,10 +378,12 @@ public class EnvelopeRepositoryTest {
     }
 
     @Test
-    void should_return_all_envelopes_when_all_params_are_null() {
+    void should_return_all_envelopes_when_all_params_are_null() throws Exception {
         //given
         UUID id1 = addEnvelope("f1", "C1");
+        Thread.sleep(1);
         UUID id2 = addEnvelope("f2", "C2");
+        Thread.sleep(1);
         UUID id3 = addEnvelope("f3", "C2");
 
         // when

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/EnvelopeRepository.java
@@ -185,7 +185,9 @@ public class EnvelopeRepository {
         }
 
         return jdbcTemplate.query(
-            "SELECT * FROM envelopes" + whereClause.toString(),
+            "SELECT * FROM envelopes"
+                + whereClause.toString()
+                + " ORDER BY created_at DESC",
             parameterSource,
             this.mapper
         );

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/events/EnvelopeEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/events/EnvelopeEventRepository.java
@@ -28,6 +28,14 @@ public class EnvelopeEventRepository {
         );
     }
 
+    public List<EnvelopeEvent> findForEnvelopes(List<UUID> envelopeIds) {
+        return jdbcTemplate.query(
+            "SELECT * FROM envelope_events WHERE envelope_id in (:envelopeIds) ORDER BY id DESC",
+            new MapSqlParameterSource("envelopeIds", envelopeIds),
+            this.mapper
+        );
+    }
+
     public long insert(NewEnvelopeEvent event) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -158,9 +158,17 @@ public class EnvelopeService {
                 .stream()
                 .map(envelope -> Tuples.of(
                     envelope,
-                    eventsByEnvelopeIds.get(envelope.id)
+                    getEnvelopeEvents(eventsByEnvelopeIds, envelope)
                 ))
                 .collect(toList());
         }
+    }
+
+    private List<EnvelopeEvent> getEnvelopeEvents(
+        Map<UUID, List<EnvelopeEvent>> eventsByEnvelopeIds,
+        Envelope envelope
+    ) {
+        List<EnvelopeEvent> envelopeEvents = eventsByEnvelopeIds.get(envelope.id);
+        return envelopeEvents == null ? emptyList() : envelopeEvents;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -18,10 +18,12 @@ import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.Instant.now;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 @Service
@@ -137,12 +139,22 @@ public class EnvelopeService {
         String containerName,
         LocalDate date
     ) {
-        return envelopeRepository
-            .findEnvelopes(blobName, containerName, date)
+        List<Envelope> envelopes = envelopeRepository
+            .findEnvelopes(blobName, containerName, date);
+
+        List<UUID> envelopeIds = envelopes.stream().map(e -> e.id).collect(toList());
+
+        List<EnvelopeEvent> envelopeEvents = eventRepository.findForEnvelopes(envelopeIds);
+
+        Map<UUID, List<EnvelopeEvent>> eventsByEnvelopeIds = envelopeEvents
+            .stream()
+            .collect(groupingBy(envelopeEvent -> envelopeEvent.envelopeId));
+
+        return envelopes
             .stream()
             .map(envelope -> Tuples.of(
                 envelope,
-                eventRepository.findForEnvelope(envelope.id)
+                eventsByEnvelopeIds.get(envelope.id)
             ))
             .collect(toList());
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.Instant.now;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
@@ -142,20 +143,24 @@ public class EnvelopeService {
         List<Envelope> envelopes = envelopeRepository
             .findEnvelopes(blobName, containerName, date);
 
-        List<UUID> envelopeIds = envelopes.stream().map(e -> e.id).collect(toList());
+        if (envelopes.isEmpty()) {
+            return emptyList();
+        } else {
+            List<UUID> envelopeIds = envelopes.stream().map(e -> e.id).collect(toList());
 
-        List<EnvelopeEvent> envelopeEvents = eventRepository.findForEnvelopes(envelopeIds);
+            List<EnvelopeEvent> envelopeEvents = eventRepository.findForEnvelopes(envelopeIds);
 
-        Map<UUID, List<EnvelopeEvent>> eventsByEnvelopeIds = envelopeEvents
-            .stream()
-            .collect(groupingBy(envelopeEvent -> envelopeEvent.envelopeId));
+            Map<UUID, List<EnvelopeEvent>> eventsByEnvelopeIds = envelopeEvents
+                .stream()
+                .collect(groupingBy(envelopeEvent -> envelopeEvent.envelopeId));
 
-        return envelopes
-            .stream()
-            .map(envelope -> Tuples.of(
-                envelope,
-                eventsByEnvelopeIds.get(envelope.id)
-            ))
-            .collect(toList());
+            return envelopes
+                .stream()
+                .map(envelope -> Tuples.of(
+                    envelope,
+                    eventsByEnvelopeIds.get(envelope.id)
+                ))
+                .collect(toList());
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -132,7 +132,18 @@ public class EnvelopeService {
     }
 
     @Transactional(readOnly = true)
-    public List<Envelope> getEnvelopes(String blobName, String containerName, LocalDate date) {
-        return envelopeRepository.findEnvelopes(blobName, containerName, date);
+    public List<Tuple2<Envelope, List<EnvelopeEvent>>> getEnvelopes(
+        String blobName,
+        String containerName,
+        LocalDate date
+    ) {
+        return envelopeRepository
+            .findEnvelopes(blobName, containerName, date)
+            .stream()
+            .map(envelope -> Tuples.of(
+                envelope,
+                eventRepository.findForEnvelope(envelope.id)
+            ))
+            .collect(toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import static java.time.Instant.now;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
@@ -268,7 +269,7 @@ class EnvelopeServiceTest {
             .willReturn(Optional.empty());
 
         // when
-        var exc = catchThrowable(() -> envelopeService.markAsRejected(notExistingId, null,"error"));
+        var exc = catchThrowable(() -> envelopeService.markAsRejected(notExistingId, null, "error"));
 
         // then
         assertThat(exc)
@@ -331,5 +332,19 @@ class EnvelopeServiceTest {
         assertThat(envelopes.get(1).getT2())
             .usingFieldByFieldElementComparator()
             .containsExactly(event1b, event1a); // should be ordered by event id
+    }
+
+    @Test
+    void should_not_call_envelope_events_repository_when_no_envelopes_exists_for_the_given_filename() {
+        // given
+        given(envelopeRepository.findEnvelopes("f1.zip", null, null)).willReturn(emptyList());
+
+        // when
+        List<Tuple2<Envelope, List<EnvelopeEvent>>> envelopes = envelopeService.getEnvelopes("f1.zip", null, null);
+
+        // then
+        verify(envelopeRepository).findEnvelopes("f1.zip", null, null);
+        assertThat(envelopes).isEmpty();
+        verifyNoInteractions(eventRepository);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1222


### Change description ###
Envelope service method should return envelope events along with envelope details.
In the next PR, Envelopes controller will use this method.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
