### PR TITLE
Add a new request parameter `date` to the envelopes endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -123,7 +123,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(1)))
             .andExpect(jsonPath("$.data[0].id").value(envelope2InDb.id.toString()))
-            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope2InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].container").value(envelope2InDb.container))
             .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
                 EventType.FILE_PROCESSING_STARTED.name(),
                 EventType.REJECTED.name()
@@ -161,13 +161,13 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(2)))
             .andExpect(jsonPath("$.data[0].id").value(envelope2InDb.id.toString()))
-            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope2InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].container").value(envelope2InDb.container))
             .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
                 EventType.FILE_PROCESSING_STARTED.name(),
                 EventType.REJECTED.name()
             )))
             .andExpect(jsonPath("$.data[1].id").value(envelope3InDb.id.toString()))
-            .andExpect(jsonPath("$.data[1].pending_notification").value(envelope3InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[1].container").value(envelope3InDb.container))
             .andExpect(jsonPath("$.data[1].events", empty()));
     }
 
@@ -177,7 +177,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
         var envelope1Event1InDb = envelopeEvent(envelope1InDb.id, 1, EventType.FILE_PROCESSING_STARTED);
         var envelope1Event2InDb = envelopeEvent(envelope1InDb.id, 2, EventType.DISPATCHED);
 
-        Envelope envelope3InDb = envelope("file2.zip", "container3", instant("2020-05-11 10:10:00"));
+        Envelope envelope2InDb = envelope("file2.zip", "container2", instant("2020-05-11 10:10:00"));
 
         given(envelopeService.getEnvelopes(null, null, null))
             .willReturn(asList(
@@ -188,7 +188,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
                         envelope1Event2InDb
                     )
                 ),
-                Tuples.of(envelope3InDb, emptyList())
+                Tuples.of(envelope2InDb, emptyList())
             ));
 
         mockMvc.perform(get("/envelopes")) // no query params
@@ -196,13 +196,13 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(2)))
             .andExpect(jsonPath("$.data[0].id").value(envelope1InDb.id.toString()))
-            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope1InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].container").value(envelope1InDb.container))
             .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
                 EventType.FILE_PROCESSING_STARTED.name(),
                 EventType.DISPATCHED.name()
             )))
-            .andExpect(jsonPath("$.data[1].id").value(envelope3InDb.id.toString()))
-            .andExpect(jsonPath("$.data[1].pending_notification").value(envelope3InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[1].id").value(envelope2InDb.id.toString()))
+            .andExpect(jsonPath("$.data[1].container").value(envelope2InDb.container))
             .andExpect(jsonPath("$.data[1].events", empty()));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.controllers;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -11,6 +12,8 @@ import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 import uk.gov.hmcts.reform.blobrouter.data.events.EnvelopeEvent;
 import uk.gov.hmcts.reform.blobrouter.data.events.EventType;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import static java.time.Instant.now;
@@ -18,12 +21,14 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.blobrouter.util.DateTimeUtils.instant;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -37,35 +42,11 @@ public class EnvelopeControllerTest extends ControllerTestBase {
         final String fileName = "some_file_name.zip";
         final String container = "some_container";
 
-        Envelope envelopeInDb = new Envelope(
-            UUID.randomUUID(),
-            container,
-            fileName,
-            now(),
-            now(),
-            now(),
-            Status.DISPATCHED,
-            false,
-            false
-        );
-        var eventRecordInDb1 = new EnvelopeEvent(
-            1,
-            envelopeInDb.id,
-            EventType.FILE_PROCESSING_STARTED,
-            null,
-            null,
-            now()
-        );
-        var eventRecordInDb2 = new EnvelopeEvent(
-            2,
-            envelopeInDb.id,
-            EventType.DISPATCHED,
-            null,
-            null,
-            now()
-        );
+        Envelope envelopeInDb = envelope(fileName, container);
+        var eventRecordInDb1 = envelopeEvent(envelopeInDb.id, 1, EventType.FILE_PROCESSING_STARTED);
+        var eventRecordInDb2 = envelopeEvent(envelopeInDb.id, 2, EventType.DISPATCHED);
 
-        given(envelopeService.getEnvelopeInfo(fileName, container))
+        given(envelopeService.getEnvelopes(fileName, container, null))
             .willReturn(singletonList(Tuples.of(
                 envelopeInDb,
                 asList(
@@ -96,7 +77,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
         final String fileName = "hello.zip";
         final String container = "foo";
 
-        given(envelopeService.getEnvelopeInfo(fileName, container))
+        given(envelopeService.getEnvelopes(fileName, container, null))
             .willReturn(emptyList());
 
         mockMvc
@@ -108,5 +89,154 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(0)));
+    }
+
+    @Test
+    void should_return_envelopes_by_file_name_and_container_and_created_date() throws Exception {
+        String container = "container1";
+
+        Envelope envelope1InDb = envelope("file1.zip", container, instant("2020-05-10 12:10:00"));
+        envelopeEvent(envelope1InDb.id, 1, EventType.FILE_PROCESSING_STARTED);
+        envelopeEvent(envelope1InDb.id, 2, EventType.DISPATCHED);
+
+        Envelope envelope2InDb = envelope("file2.zip", container, instant("2020-05-11 08:10:00"));
+        var envelope2Event1InDb = envelopeEvent(envelope2InDb.id, 3, EventType.FILE_PROCESSING_STARTED);
+        var envelope2Event2InDb = envelopeEvent(envelope2InDb.id, 4, EventType.REJECTED);
+
+        given(envelopeService.getEnvelopes("file2.zip", container, LocalDate.of(2020, 5, 11)))
+            .willReturn(singletonList(Tuples.of(
+                envelope2InDb,
+                asList(
+                    envelope2Event1InDb,
+                    envelope2Event2InDb
+                )
+            )));
+
+        mockMvc
+            .perform(
+                get("/envelopes")
+                    .queryParam("file_name", "file2.zip")
+                    .queryParam("container", container)
+                    .queryParam("date", "2020-05-11")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data", hasSize(1)))
+            .andExpect(jsonPath("$.data[0].id").value(envelope2InDb.id.toString()))
+            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope2InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
+                EventType.FILE_PROCESSING_STARTED.name(),
+                EventType.REJECTED.name()
+            )));
+    }
+
+    @Test
+    void should_return_envelopes_for_the_requested_date() throws Exception {
+        Envelope envelope1InDb = envelope("file1.zip", "container1", instant("2020-05-10 12:10:00"));
+        envelopeEvent(envelope1InDb.id, 1, EventType.FILE_PROCESSING_STARTED);
+        envelopeEvent(envelope1InDb.id, 2, EventType.DISPATCHED);
+
+        Envelope envelope2InDb = envelope("file2.zip", "container2", instant("2020-05-11 08:10:00"));
+        var envelope2Event1InDb = envelopeEvent(envelope2InDb.id, 3, EventType.FILE_PROCESSING_STARTED);
+        var envelope2Event2InDb = envelopeEvent(envelope2InDb.id, 4, EventType.REJECTED);
+
+        Envelope envelope3InDb = envelope("file3.zip", "container3", instant("2020-05-11 10:10:00"));
+
+        given(envelopeService.getEnvelopes(null, null, LocalDate.of(2020, 5, 11)))
+            .willReturn(asList(
+                Tuples.of(
+                    envelope2InDb,
+                    asList(
+                        envelope2Event1InDb,
+                        envelope2Event2InDb
+                    )
+                ),
+                Tuples.of(envelope3InDb, emptyList())
+            ));
+
+        mockMvc.perform(
+            get("/envelopes").queryParam("date", "2020-05-11")
+        )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data", hasSize(2)))
+            .andExpect(jsonPath("$.data[0].id").value(envelope2InDb.id.toString()))
+            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope2InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
+                EventType.FILE_PROCESSING_STARTED.name(),
+                EventType.REJECTED.name()
+            )))
+            .andExpect(jsonPath("$.data[1].id").value(envelope3InDb.id.toString()))
+            .andExpect(jsonPath("$.data[1].pending_notification").value(envelope3InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[1].events", empty()));
+    }
+
+    @Test
+    void should_return_all_envelopes_when_no_request_params_provided() throws Exception {
+        Envelope envelope1InDb = envelope("file1.zip", "container1", instant("2020-05-10 12:10:00"));
+        var envelope1Event1InDb = envelopeEvent(envelope1InDb.id, 1, EventType.FILE_PROCESSING_STARTED);
+        var envelope1Event2InDb = envelopeEvent(envelope1InDb.id, 2, EventType.DISPATCHED);
+
+        Envelope envelope3InDb = envelope("file2.zip", "container3", instant("2020-05-11 10:10:00"));
+
+        given(envelopeService.getEnvelopes(null, null, null))
+            .willReturn(asList(
+                Tuples.of(
+                    envelope1InDb,
+                    asList(
+                        envelope1Event1InDb,
+                        envelope1Event2InDb
+                    )
+                ),
+                Tuples.of(envelope3InDb, emptyList())
+            ));
+
+        mockMvc.perform(get("/envelopes")) // no query params
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data", hasSize(2)))
+            .andExpect(jsonPath("$.data[0].id").value(envelope1InDb.id.toString()))
+            .andExpect(jsonPath("$.data[0].pending_notification").value(envelope1InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[0].events[*].event").value(contains(
+                EventType.FILE_PROCESSING_STARTED.name(),
+                EventType.DISPATCHED.name()
+            )))
+            .andExpect(jsonPath("$.data[1].id").value(envelope3InDb.id.toString()))
+            .andExpect(jsonPath("$.data[1].pending_notification").value(envelope3InDb.pendingNotification))
+            .andExpect(jsonPath("$.data[1].events", empty()));
+    }
+
+    @Test
+    public void should_return_400_for_invalid_date() throws Exception {
+        mockMvc.perform(
+            get("/envelopes").queryParam("date", "2020011") // invalid date
+        )
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    @NotNull
+    private Envelope envelope(String fileName, String container, Instant createdDate) {
+        return new Envelope(
+            UUID.randomUUID(),
+            container,
+            fileName,
+            createdDate,
+            now(),
+            now(),
+            Status.DISPATCHED,
+            false,
+            false
+        );
+    }
+
+    @NotNull
+    private Envelope envelope(String fileName, String container) {
+        return envelope(fileName, container, now());
+    }
+
+    @NotNull
+    private EnvelopeEvent envelopeEvent(UUID envelopeId, int eventId, EventType eventType) {
+        return new EnvelopeEvent(eventId, envelopeId, eventType, null, null, now());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.blobrouter.controllers;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,9 +13,11 @@ import uk.gov.hmcts.reform.blobrouter.model.out.EnvelopeInfo;
 import uk.gov.hmcts.reform.blobrouter.model.out.SearchResult;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
 @RestController
 @RequestMapping(path = "/envelopes", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -28,12 +31,13 @@ public class EnvelopeController {
 
     @GetMapping()
     public SearchResult findEnvelopes(
-        @RequestParam("file_name") String fileName,
-        @RequestParam("container") String container
+        @RequestParam(name = "file_name", required = false) String fileName,
+        @RequestParam(name = "container", required = false) String container,
+        @RequestParam(name = "date", required = false) @DateTimeFormat(iso = DATE) LocalDate date
     ) {
         return new SearchResult(
             envelopeService
-                .getEnvelopeInfo(fileName, container)
+                .getEnvelopes(fileName, container, date)
                 .stream()
                 .map(tuple -> toResponse(tuple.getT1(), tuple.getT2()))
                 .collect(toList())


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1222


### Change description ###
- Add a new request parameter `date`(format - `2020-05-11`)
- Make all request parameters optional.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
