### PR TITLE
Added secret mapping and bootstrap config for staging infrastructure

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -30,7 +30,7 @@ def combinedSecrets = [
      secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY'),
 
      secret('storage-account-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
-     secret('storage-account-name', 'TEST_STORAGE_ACCOUNT_NAME'),
+     secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_NAME'),
    ]
  ]
 
@@ -88,7 +88,7 @@ withPipeline(type, product, component) {
 
   // Vars needed for smoke / functional testing
   env.TEST_STORAGE_CONTAINER_NAME = 'bulkscan'
-  env.TEST_STORAGE_ACCOUNT_URL = 'https://reformscanaat.blob.core.windows.net'
+  env.TEST_STORAGE_ACCOUNT_URL = 'https://reformscanaatstaging.blob.core.windows.net'
   env.API_GATEWAY_URL = "https://core-api-mgmt-aat.azure-api.net/reform-scan"
 
   before('smoketest:preview') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -29,8 +29,8 @@ def combinedSecrets = [
 
      secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY'),
 
-     secret('storage-account-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
-     secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_NAME'),
+     secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
+     secret('storage-account-staging-name', 'TEST_STORAGE_ACCOUNT_NAME'),
    ]
  ]
 

--- a/charts/reform-scan-blob-router/values.aat.template.yaml
+++ b/charts/reform-scan-blob-router/values.aat.template.yaml
@@ -8,3 +8,21 @@ java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   devApplicationInsightsInstrumentKey: "fb929548-3309-4933-bd6e-f7932b4e0309"
+  keyVaults:
+    reform-scan:
+      resourceGroup: reform-scan
+      secrets:
+        - app-insights-instrumentation-key
+        - reports-email-username
+        - reports-email-password
+        - reports-recipients
+        - storage-account-name
+        - storage-account-primary-key
+        - storage-account-secondary-key
+        - crime-storage-connection-string
+        - blob-router-staging-db-password
+        - blob-router-staging-db-user
+        - blob-router-staging-db-host
+        - blob-router-staging-db-port
+        - blob-router-staging-db-name
+        - notifications-staging-queue-send-connection-string

--- a/charts/reform-scan-blob-router/values.aat.template.yaml
+++ b/charts/reform-scan-blob-router/values.aat.template.yaml
@@ -4,6 +4,7 @@ java:
     STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
     DELETE_DISPATCHED_FILES_CRON: "0/10 * * * * *"
     SEND_NOTIFICATIONS_CRON: "0/10 * * * * *"
+    FLYWAY_SKIP_MIGRATIONS: false
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/reform-scan-blob-router/values.aat.template.yaml
+++ b/charts/reform-scan-blob-router/values.aat.template.yaml
@@ -17,9 +17,9 @@ java:
         - reports-email-username
         - reports-email-password
         - reports-recipients
-        - storage-account-name
-        - storage-account-primary-key
-        - storage-account-secondary-key
+        - storage-account-staging-name
+        - storage-account-staging-primary-key
+        - storage-account-staging-secondary-key
         - crime-storage-connection-string
         - blob-router-staging-db-password
         - blob-router-staging-db-user

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -10,6 +10,9 @@ spring:
         storage-account-name: storage.account-name
         storage-account-primary-key:  storage.account-key
         storage-account-secondary-key:  storage.account-secondary-key
+        storage-account-staging-name: storage.account-name
+        storage-account-staging-primary-key:  storage.account-key
+        storage-account-staging-secondary-key:  storage.account-secondary-key
         crime-storage-connection-string: storage.crime.connection-string
         reports-email-username: SMTP_USERNAME
         reports-email-password: SMTP_PASSWORD
@@ -19,4 +22,10 @@ spring:
         blob-router-POSTGRES-DATABASE: DB_NAME
         blob-router-POSTGRES-HOST: DB_HOST
         blob-router-POSTGRES-PORT: DB_PORT
+        blob-router-staging-db-password: DB_PASSWORD
+        blob-router-staging-db-user: DB_USER
+        blob-router-staging-db-host: DB_HOST
+        blob-router-staging-db-port: DB_PORT
+        blob-router-staging-db-name: DB_NAME
         notifications-queue-send-connection-string: NOTIFICATIONS_QUEUE_CONNECTION_STRING
+        notifications-staging-queue-send-connection-string: NOTIFICATIONS_QUEUE_CONNECTION_STRING


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1216

### Change description ###

- This PR overrides database , blob storage and queue connection string secrets with staging infra ones. 

- Other secrets remain same but needs to be present while overriding.

- This PR is dependent on https://github.com/hmcts/reform-scan-shared-infra/pull/43 to create secrets in key vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
