### PR TITLE
Update key vault and storage account url in the zipfile upload script

### DIFF
--- a/bin/sign-zip-upload.sh
+++ b/bin/sign-zip-upload.sh
@@ -61,7 +61,7 @@ echo "Verifying private key for zipping is present..."
 PEM_EXISTS="false"
 
 if [[ ! -f "private.pem" ]]; then
-  az keyvault secret show --vault-name "bulk-scan-$ENVI" --name test-private-key-der | jq -r .value | fold -s -w64 > private.pem
+  az keyvault secret show --vault-name "reform-scan-$ENVI" --name storage-account-primary-key | jq -r .value | fold -s -w64 > private.pem
   exec 3<> private.pem && awk -v TEXT="-----BEGIN RSA PRIVATE KEY-----" 'BEGIN {print TEXT}{print}' private.pem >&3
   echo "-----END RSA PRIVATE KEY-----" >> private.pem
   PEM_EXISTS="true"
@@ -91,7 +91,7 @@ rm ${SIGNATURE_FILE_NAME}
 
 echo "Uploading $ZIP_FILE_NAME to blob storage..."
 
-UPLOAD_COMMAND=`curl -i -X PUT --upload-file "$ZIP_FILE_NAME" -H "x-ms-date: $(date -u)" -H "x-ms-blob-type: BlockBlob" -H "Content-Type: application/octet-stream" "http://bulkscan$ENVI.blob.core.windows.net/$CONTAINER/$ZIP_FILE_NAME?$SAS_TOKEN"`
+UPLOAD_COMMAND=`curl -i -X PUT --upload-file "$ZIP_FILE_NAME" -H "x-ms-date: $(date -u)" -H "x-ms-blob-type: BlockBlob" -H "Content-Type: application/octet-stream" "http://reformscan$ENVI.blob.core.windows.net/$CONTAINER/$ZIP_FILE_NAME?$SAS_TOKEN"`
 
 if [[ ${UPLOAD_COMMAND} == *"201 Created"* ]]; then
   echo "Uploaded $ZIP_FILE_NAME to blob storage"


### PR DESCRIPTION
### Change description ###
The `sign-zip-upload.sh` script was moved from bulk-scan-processor to blob-router, but the key vault and the storage account URLs are not `reform-scan` resources. 
Updated the script to use the reform scan storage account and key vault.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
