### PR TITLE
CVE-2020-5407 - use different version to avoid vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,8 @@ dependencyManagement {
       entry 'log4j-to-slf4j'
       entry 'log4j-api'
     }
+    //CVE-2020-5407, remove once spring cloud is updated
+    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.2.4.RELEASE'
   }
 }
 


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

to avoid CVE-2020-5407
use different version of spring security vulnerabilities

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
