### PR TITLE
Always include 'create' permissions instead of 'write' in SAS tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,12 @@ dependencyManagement {
     }
     //CVE-2020-5407, remove once spring cloud is updated
     dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.2.4.RELEASE'
+    
+    // CVE-2020-9484 present in 9.0.34
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.35') {
+       entry 'tomcat-embed-core'
+       entry 'tomcat-embed-websocket'
+    }
   }
 }
 

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.0.43
+version: 0.0.44
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -43,7 +43,6 @@ java:
 
     SMTP_HOST: "false"
     SEND_DAILY_REPORT_ENABLED: "false"
-    INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: true
   image: 'hmctspublic.azurecr.io/reform-scan/blob-router:latest'
 reformblobstorage:
   enabled: false

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -45,5 +45,3 @@ spring.mail.host=localhost
 spring.mail.port=3025
 spring.mail.username=test_username
 spring.mail.password=test_password
-
-include-write-permission-in-storage-sas-token=false

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/SasTokenGeneratorService.java
@@ -6,7 +6,6 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.common.sas.SasProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.blobrouter.config.ServiceConfiguration;
@@ -25,16 +24,13 @@ public class SasTokenGeneratorService {
 
     private final StorageSharedKeyCredential storageSharedKeyCredential;
     private final ServiceConfiguration serviceConfiguration;
-    private final boolean includeWritePermissionInSasToken;
 
     public SasTokenGeneratorService(
         StorageSharedKeyCredential storageSharedKeyCredential,
-        ServiceConfiguration serviceConfiguration,
-        @Value("${include-write-permission-in-storage-sas-token}") boolean includeWritePermissionInSasToken
+        ServiceConfiguration serviceConfiguration
     ) {
         this.storageSharedKeyCredential = storageSharedKeyCredential;
         this.serviceConfiguration = serviceConfiguration;
-        this.includeWritePermissionInSasToken = includeWritePermissionInSasToken;
     }
 
     public String generateSasToken(String serviceName) {
@@ -53,8 +49,7 @@ public class SasTokenGeneratorService {
 
         var permissions = new BlobContainerSasPermission()
             .setListPermission(true)
-            .setCreatePermission(!includeWritePermissionInSasToken)
-            .setWritePermission(includeWritePermissionInSasToken);
+            .setCreatePermission(true);
 
         return new BlobServiceSasSignatureValues()
             .setContainerName(serviceName)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,7 +88,6 @@ flyway:
   skip-migrations: ${FLYWAY_SKIP_MIGRATIONS}
 
 storage-blob-processing-delay-in-minutes: ${STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES}
-include-write-permission-in-storage-sas-token: ${INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN}
 public_key_der_file: ${STORAGE_BLOB_PUBLIC_KEY} # public key file in der format
 
 bulk-scan-cache:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1187

### Change description ###

Always include `create` permissions instead of `write` in SAS tokens. `Create` permission has proven to be sufficient in prod, so no need to configure it.

Next: cleanup in flux config.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
