### PR TITLE
Set proxy for blob storage client as it will be rejected otherwise

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/FunctionalTestBase.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter;
 
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.common.StorageSharedKeyCredential;
@@ -7,6 +9,7 @@ import io.restassured.RestAssured;
 import uk.gov.hmcts.reform.blobrouter.config.TestConfiguration;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 
+import java.net.InetSocketAddress;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.ThreadLocalRandom;
@@ -32,6 +35,19 @@ public abstract class FunctionalTestBase {
         );
 
         this.blobRouterStorageClient = new BlobServiceClientBuilder()
+            .httpClient(
+                new NettyAsyncHttpClientBuilder()
+                    .proxy(
+                        new ProxyOptions(
+                            ProxyOptions.Type.HTTP,
+                            new InetSocketAddress(
+                                "proxyout.reform.hmcts.net",
+                                8080
+                            )
+                        )
+                    )
+                    .build()
+            )
             .credential(blobRouterStorageCredential)
             .endpoint(config.sourceStorageAccountUrl)
             .buildClient();


### PR DESCRIPTION

### Change description ###

- Set proxy for functional tests so that all requests goes through proxy and they don't get blocked due NSG rules.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
