### PR TITLE
Refactor `LeaseAcquirer` to be able to consume leaseId

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -24,6 +24,12 @@ public class LeaseAcquirer {
         this.leaseClientProvider = leaseClientProvider;
     }
 
+    /**
+     * Main wrapper for blobs to be leased by {@link BlobLeaseClient}.
+     * @param blobClient Represents blob
+     * @param onSuccess Consumer which takes in {@code leaseId} acquired with {@link BlobLeaseClient}
+     * @param onBlobNotFound Extra step to execute in case blob was not found during leasing
+     */
     public void ifAcquiredOrElse(BlobClient blobClient, Consumer<String> onSuccess, Runnable onBlobNotFound) {
         try {
             var leaseClient = leaseClientProvider.get(blobClient);

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -55,7 +55,7 @@ public class LeaseAcquirer {
         }
     }
 
-    public void ifAcquiredOrElse(BlobClient blobClient, Runnable onSuccess) {
+    public void ifAcquired(BlobClient blobClient, Runnable onSuccess) {
         ifAcquiredOrElse(blobClient, leaseId -> onSuccess.run(), () -> {});
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -22,7 +22,7 @@ public class LeaseAcquirer {
         this.leaseClientProvider = leaseClientProvider;
     }
 
-    public void ifAcquiredOrElse(BlobClient blobClient, Runnable onSuccess, Runnable onFailure) {
+    public void ifAcquiredOrElse(BlobClient blobClient, Runnable onSuccess) {
         try {
             var leaseClient = leaseClientProvider.get(blobClient);
             leaseClient.acquireLease(LEASE_DURATION_IN_SECONDS);
@@ -41,7 +41,13 @@ public class LeaseAcquirer {
                 );
             }
 
-            onFailure.run();
+            if (exc.getErrorCode() != BLOB_NOT_FOUND) {
+                logger.info(
+                    "Cannot acquire a lease for blob - skipping. File name: {}, container: {}",
+                    blobClient.getBlobName(),
+                    blobClient.getContainerName()
+                );
+            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -78,15 +78,12 @@ public class ContainerProcessor {
             .ifPresentOrElse(
                 envelope -> {
                     if (envelope.status == Status.CREATED) {
-                        leaseAcquirer.ifAcquiredOrElse(
-                            blob,
-                            () -> blobProcessor.continueProcessing(envelope.id, blob)
-                        );
+                        leaseAcquirer.ifAcquired(blob, () -> blobProcessor.continueProcessing(envelope.id, blob));
                     } else {
                         logger.info("Envelope already processed in system, skipping. {} ", envelope.getBasicInfo());
                     }
                 },
-                () -> leaseAcquirer.ifAcquiredOrElse(blob, () -> blobProcessor.process(blob))
+                () -> leaseAcquirer.ifAcquired(blob, () -> blobProcessor.process(blob))
             );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -78,26 +78,15 @@ public class ContainerProcessor {
             .ifPresentOrElse(
                 envelope -> {
                     if (envelope.status == Status.CREATED) {
-                        leaseAndThen(blob, () -> blobProcessor.continueProcessing(envelope.id, blob));
+                        leaseAcquirer.ifAcquiredOrElse(
+                            blob,
+                            () -> blobProcessor.continueProcessing(envelope.id, blob)
+                        );
                     } else {
                         logger.info("Envelope already processed in system, skipping. {} ", envelope.getBasicInfo());
                     }
                 },
-                () -> {
-                    leaseAndThen(blob, () -> blobProcessor.process(blob));
-                }
+                () -> leaseAcquirer.ifAcquiredOrElse(blob, () -> blobProcessor.process(blob))
             );
-    }
-
-    private void leaseAndThen(BlobClient blob, Runnable action) {
-        leaseAcquirer.ifAcquiredOrElse(
-            blob,
-            action,
-            () -> logger.info(
-                "Cannot acquire a lease for blob - skipping. File name: {}, container: {}",
-                blob.getBlobName(),
-                blob.getContainerName()
-            )
-        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -27,16 +27,14 @@ class LeaseAcquirerTest {
     void should_run_provided_action_when_lease_was_acquired() {
         // given
         var onSuccess = mock(Runnable.class);
-        var onFailure = mock(Runnable.class);
 
         var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
 
         // then
         verify(onSuccess).run();
-        verify(onFailure, never()).run();
 
         verify(leaseClient).releaseLease();
     }
@@ -45,18 +43,16 @@ class LeaseAcquirerTest {
     void should_run_provided_action_when_lease_was_not_acquired() {
         // given
         var onSuccess = mock(Runnable.class);
-        var onFailure = mock(Runnable.class);
 
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
         var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
 
         // then
         verify(onSuccess, never()).run();
-        verify(onFailure).run();
 
         verify(leaseClient, never()).releaseLease();
     }
@@ -65,19 +61,17 @@ class LeaseAcquirerTest {
     void should_handle_error_when_releasing_lease() {
         // given
         var onSuccess = mock(Runnable.class);
-        var onFailure = mock(Runnable.class);
 
         doThrow(blobStorageException).when(leaseClient).releaseLease();
 
         var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
 
         // when
-        var exc = catchThrowable(() -> leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure));
+        var exc = catchThrowable(() -> leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess));
 
         // then
         assertThat(exc).isNull();
         verify(onSuccess).run();
-        verify(onFailure, never()).run();
 
         verify(leaseClient).releaseLease();
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.blobrouter.services.storage;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,12 +27,17 @@ class LeaseAcquirerTest {
     @Mock BlobLeaseClient leaseClient;
     @Mock BlobStorageException blobStorageException;
 
+    private LeaseAcquirer leaseAcquirer;
+
+    @BeforeEach
+    void setUp() {
+        leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
+    }
+
     @Test
     void should_run_provided_action_when_lease_was_acquired() {
         // given
         var onSuccess = mock(Runnable.class);
-
-        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
 
         // when
         leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
@@ -49,8 +55,6 @@ class LeaseAcquirerTest {
 
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
-        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
-
         // when
         leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
 
@@ -66,8 +70,6 @@ class LeaseAcquirerTest {
         var onSuccess = mock(Runnable.class);
 
         doThrow(blobStorageException).when(leaseClient).releaseLease();
-
-        var leaseAcquirer = new LeaseAcquirer(blobClient -> leaseClient);
 
         // when
         var exc = catchThrowable(() -> leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess));
@@ -86,7 +88,6 @@ class LeaseAcquirerTest {
         var onBlobNotFound = mock(Runnable.class);
         doThrow(blobStorageException).when(leaseClient).acquireLease(LEASE_DURATION_IN_SECONDS);
         when(blobStorageException.getErrorCode()).thenReturn(BLOB_NOT_FOUND);
-        var leaseAcquirer = new LeaseAcquirer(blobClient1 -> leaseClient);
 
         // when
         leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onBlobNotFound);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -9,10 +9,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.function.Consumer;
+
 import static com.azure.storage.blob.models.BlobErrorCode.BLOB_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -81,10 +84,11 @@ class LeaseAcquirerTest {
         verify(leaseClient).releaseLease();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void should_run_custom_function_when_blob_not_found() {
         // given
-        var onSuccess = mock(Runnable.class);
+        var onSuccess = mock(Consumer.class);
         var onBlobNotFound = mock(Runnable.class);
         doThrow(blobStorageException).when(leaseClient).acquireLease(LEASE_DURATION_IN_SECONDS);
         when(blobStorageException.getErrorCode()).thenReturn(BLOB_NOT_FOUND);
@@ -93,7 +97,7 @@ class LeaseAcquirerTest {
         leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onBlobNotFound);
 
         // then
-        verify(onSuccess, never()).run();
+        verify(onSuccess, never()).accept(anyString());
         verify(onBlobNotFound).run();
         verify(leaseClient, never()).releaseLease();
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -43,7 +43,7 @@ class LeaseAcquirerTest {
         var onSuccess = mock(Runnable.class);
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
+        leaseAcquirer.ifAcquired(blobClient, onSuccess);
 
         // then
         verify(onSuccess).run();
@@ -59,7 +59,7 @@ class LeaseAcquirerTest {
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess);
+        leaseAcquirer.ifAcquired(blobClient, onSuccess);
 
         // then
         verify(onSuccess, never()).run();
@@ -75,7 +75,7 @@ class LeaseAcquirerTest {
         doThrow(blobStorageException).when(leaseClient).releaseLease();
 
         // when
-        var exc = catchThrowable(() -> leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess));
+        var exc = catchThrowable(() -> leaseAcquirer.ifAcquired(blobClient, onSuccess));
 
         // then
         assertThat(exc).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -139,7 +139,7 @@ class ContainerProcessorTest {
             var okAction = (Runnable) invocation.getArgument(1);
             okAction.run();
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any());
+        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any());
     }
 
     private void leaseCannotBeAcquired() {
@@ -147,7 +147,7 @@ class ContainerProcessorTest {
             var failureAction = (Runnable) invocation.getArgument(2);
             failureAction.run();
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any());
+        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any());
     }
 
     private Envelope envelope(Status status) {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -139,7 +139,7 @@ class ContainerProcessorTest {
             var okAction = (Runnable) invocation.getArgument(1);
             okAction.run();
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any());
+        }).when(leaseAcquirer).ifAcquired(any(), any());
     }
 
     private void leaseCannotBeAcquired() {
@@ -147,7 +147,7 @@ class ContainerProcessorTest {
             var failureAction = (Runnable) invocation.getArgument(2);
             failureAction.run();
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any());
+        }).when(leaseAcquirer).ifAcquired(any(), any());
     }
 
     private Envelope envelope(Status status) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Acquire lease on blobs before deleting them](https://tools.hmcts.net/jira/browse/BPS-1205)

### Change description ###

First step - prepare the success function to accept leaseId in order to be able to use in `ContainerCleaner`. Reference: #544 - sort of complete working code

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
