### PR TITLE
Feature: acquire lease before deleting dispatched blob

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/ContainerCleanerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/storage/ContainerCleanerTest.java
@@ -46,6 +46,9 @@ public class ContainerCleanerTest extends BlobStorageBaseTest {
     private EnvelopeRepository envelopeRepository;
 
     @Autowired
+    private LeaseAcquirer leaseAcquirer;
+
+    @Autowired
     private DbHelper dbHelper;
 
     BlobContainerClient containerClient;
@@ -55,7 +58,7 @@ public class ContainerCleanerTest extends BlobStorageBaseTest {
         dbHelper.deleteAll();
         containerClient = createContainer(CONTAINER_NAME);
 
-        containerCleaner = new ContainerCleaner(storageClient, envelopeService);
+        containerCleaner = new ContainerCleaner(storageClient, envelopeService, leaseAcquirer);
     }
 
     @AfterEach

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
@@ -5,9 +5,7 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobRequestConditions;
-import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
-import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
@@ -87,33 +85,13 @@ public class ContainerCleaner {
                 envelope.fileName,
                 blobClient.getContainerName()
             );
-        } catch (BlobStorageException ex) {
-            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                logger.error(
-                    String.format(
-                        "Blob %s does not exist in container %s",
-                        envelope.fileName,
-                        blobClient.getContainerName()
-                    ),
-                    ex
-                );
-                envelopeService.markEnvelopeAsDeleted(envelope);
-            } else {
-                logException(envelope, blobClient, ex);
-            }
         } catch (Exception ex) {
-            logException(envelope, blobClient, ex);
-        }
-    }
-
-    private void logException(Envelope envelope, BlobClient blobClient, Exception ex) {
-        logger.error(
-            String.format(
-                "Error deleting dispatched blob %s from container %s",
+            logger.error(
+                "Error deleting dispatched blob {} from container {}",
                 envelope.fileName,
-                blobClient.getContainerName()
-            ),
-            ex
-        );
+                blobClient.getContainerName(),
+                ex
+            );
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
@@ -56,12 +56,14 @@ public class ContainerCleaner {
         leaseAcquirer.ifAcquiredOrElse(
             blobClient,
             leaseId -> tryToDeleteBlob(envelope, blobClient, leaseId),
-            () -> {
+            errorCode -> {
                 envelopeService.markEnvelopeAsDeleted(envelope);
                 logger.info(
-                    "Marked blob as deleted. File name: {}, container: {}",
+                    // once cleared up - i'll create amendment as at this stage we should not care about error code
+                    "Marked blob as deleted. File name: {}, container: {}, original error code: {}",
                     envelope.fileName,
-                    blobClient.getContainerName()
+                    blobClient.getContainerName(),
+                    errorCode
                 );
             }
         );

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
@@ -10,7 +10,6 @@ import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -138,30 +137,6 @@ class ContainerCleanerTest {
         // and
         verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_1);
         verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_2);
-        verifyNoMoreInteractions(envelopeService);
-    }
-
-    @Disabled("will be removed in next commit as 404 has been replaced with lease id condition")
-    @Test
-    void should_handle_non_existing_file() {
-        // given
-        given(envelopeService.getReadyToDeleteDispatches(CONTAINER_NAME))
-            .willReturn(singletonList(
-                ENVELOPE_1
-            ));
-        given(containerClient.getBlobClient(ENVELOPE_1.fileName)).willReturn(blobClient1);
-        doThrow(new BlobStorageException("msg", new MockHttpResponse(null, 404), null))
-            .when(blobClient1).delete();
-
-        // when
-        assertThatCode(() -> containerCleaner.process(CONTAINER_NAME)).doesNotThrowAnyException();
-
-        // then
-        verify(containerClient).getBlobClient(ENVELOPE_1.fileName);
-        verifyNoMoreInteractions(containerClient);
-        verify(blobClient1).getContainerName();
-        verify(blobClient1).delete();
-        verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_1);
         verifyNoMoreInteractions(envelopeService);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleanerTest.java
@@ -1,18 +1,25 @@
 package uk.gov.hmcts.reform.blobrouter.tasks.processors;
 
 import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.util.Context;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
+import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Envelope;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
+import uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -20,10 +27,12 @@ import java.util.UUID;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -41,13 +50,18 @@ class ContainerCleanerTest {
     @Mock BlobContainerClient containerClient;
     @Mock BlobClient blobClient1;
     @Mock BlobClient blobClient2;
+    @Mock BlobLeaseClient leaseClient;
 
     private static final Envelope ENVELOPE_1 = createEnvelope(UUID.randomUUID(), DISPATCHED, "file1.zip");
     private static final Envelope ENVELOPE_2 = createEnvelope(UUID.randomUUID(), DISPATCHED, "file2.zip");
 
     @BeforeEach
     void setUp() {
-        containerCleaner = new ContainerCleaner(storageClient, envelopeService);
+        containerCleaner = new ContainerCleaner(
+            storageClient,
+            envelopeService,
+            new LeaseAcquirer(blobClient -> leaseClient)
+        );
 
         given(storageClient.getBlobContainerClient(CONTAINER_NAME)).willReturn(containerClient);
     }
@@ -86,6 +100,9 @@ class ContainerCleanerTest {
             ));
         given(containerClient.getBlobClient(ENVELOPE_1.fileName)).willReturn(blobClient1);
         given(containerClient.getBlobClient(ENVELOPE_2.fileName)).willReturn(blobClient2);
+        String leaseId1 = UUID.randomUUID().toString();
+        String leaseId2 = UUID.randomUUID().toString();
+        given(leaseClient.acquireLease(LeaseAcquirer.LEASE_DURATION_IN_SECONDS)).willReturn(leaseId1, leaseId2);
 
         // when
         containerCleaner.process(CONTAINER_NAME);
@@ -93,15 +110,38 @@ class ContainerCleanerTest {
         // then
         verify(containerClient).getBlobClient(ENVELOPE_1.fileName);
         verify(containerClient).getBlobClient(ENVELOPE_2.fileName);
-        verify(containerClient, times(2)).getBlobContainerName();
         verifyNoMoreInteractions(containerClient);
-        verify(blobClient1).delete();
-        verify(blobClient2).delete();
+        verify(blobClient1).getContainerName();
+        verify(blobClient2).getContainerName();
+
+        // and
+        var conditionCaptor = ArgumentCaptor.forClass(BlobRequestConditions.class);
+
+        verify(blobClient1).deleteWithResponse(
+            eq(DeleteSnapshotsOptionType.INCLUDE),
+            conditionCaptor.capture(),
+            eq(null),
+            eq(Context.NONE)
+        );
+        verify(blobClient2).deleteWithResponse(
+            eq(DeleteSnapshotsOptionType.INCLUDE),
+            conditionCaptor.capture(),
+            eq(null),
+            eq(Context.NONE)
+        );
+
+        assertThat(conditionCaptor.getAllValues())
+            .hasSize(2)
+            .extracting(BlobRequestConditions::getLeaseId)
+            .containsExactly(leaseId1, leaseId2);
+
+        // and
         verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_1);
         verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_2);
         verifyNoMoreInteractions(envelopeService);
     }
 
+    @Disabled("will be removed in next commit as 404 has been replaced with lease id condition")
     @Test
     void should_handle_non_existing_file() {
         // given
@@ -118,8 +158,8 @@ class ContainerCleanerTest {
 
         // then
         verify(containerClient).getBlobClient(ENVELOPE_1.fileName);
-        verify(containerClient).getBlobContainerName();
         verifyNoMoreInteractions(containerClient);
+        verify(blobClient1).getContainerName();
         verify(blobClient1).delete();
         verify(envelopeService).markEnvelopeAsDeleted(ENVELOPE_1);
         verifyNoMoreInteractions(envelopeService);
@@ -133,17 +173,19 @@ class ContainerCleanerTest {
                 ENVELOPE_1
             ));
         given(containerClient.getBlobClient(ENVELOPE_1.fileName)).willReturn(blobClient1);
+        given(leaseClient.acquireLease(LeaseAcquirer.LEASE_DURATION_IN_SECONDS))
+            .willReturn(UUID.randomUUID().toString());
         doThrow(new BlobStorageException("msg", new MockHttpResponse(null, 500), null))
-            .when(blobClient1).delete();
+            .when(blobClient1).deleteWithResponse(any(), any(), eq(null), eq(Context.NONE));
 
         // when
         assertThatCode(() -> containerCleaner.process(CONTAINER_NAME)).doesNotThrowAnyException();
 
         // then
         verify(containerClient).getBlobClient(ENVELOPE_1.fileName);
-        verify(containerClient).getBlobContainerName();
         verifyNoMoreInteractions(containerClient);
-        verify(blobClient1).delete();
+        verify(blobClient1).getContainerName();
+        verify(blobClient1).deleteWithResponse(any(), any(), eq(null), eq(Context.NONE));
         verifyNoMoreInteractions(envelopeService);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Acquire lease on blobs before deleting them](https://tools.hmcts.net/jira/browse/BPS-1205)

### Change description ###

Note: not found section no longer applies as it is handled when acquiring lease

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
