### PR TITLE
Change 3rd argument to Consumer instead

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
@@ -66,7 +66,7 @@ public class RejectedContainerCleaner {
             .forEach(blobClient -> leaseAcquirer.ifAcquiredOrElse(
                 blobClient,
                 leaseId -> delete(blobClient, leaseId),
-                () -> {} // nothing to do if blob not found in rejected container
+                errorCode -> {} // nothing to do if blob not found in rejected container
             ));
 
         logger.info("Finished removing rejected files. Container: {}", containerName);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.blobrouter.services.storage;
 
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,19 +12,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Consumer;
 
-import static com.azure.storage.blob.models.BlobErrorCode.BLOB_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer.LEASE_DURATION_IN_SECONDS;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
 class LeaseAcquirerTest {
 
     @Mock BlobClient blobClient;
@@ -40,65 +40,50 @@ class LeaseAcquirerTest {
     @Test
     void should_run_provided_action_when_lease_was_acquired() {
         // given
-        var onSuccess = mock(Runnable.class);
+        var onSuccess = mock(Consumer.class);
+        var onFailure = mock(Consumer.class);
 
         // when
-        leaseAcquirer.ifAcquired(blobClient, onSuccess);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
 
         // then
-        verify(onSuccess).run();
-
+        verify(onSuccess).accept(null);
+        verify(onFailure, never()).accept(any(BlobErrorCode.class));
         verify(leaseClient).releaseLease();
     }
 
     @Test
     void should_run_provided_action_when_lease_was_not_acquired() {
         // given
-        var onSuccess = mock(Runnable.class);
+        var onSuccess = mock(Consumer.class);
+        var onFailure = mock(Consumer.class);
 
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
         // when
-        leaseAcquirer.ifAcquired(blobClient, onSuccess);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
 
         // then
-        verify(onSuccess, never()).run();
-
+        verify(onSuccess, never()).accept(anyString());
+        verify(onFailure).accept(null);
         verify(leaseClient, never()).releaseLease();
     }
 
     @Test
     void should_handle_error_when_releasing_lease() {
         // given
-        var onSuccess = mock(Runnable.class);
+        var onSuccess = mock(Consumer.class);
+        var onFailure = mock(Consumer.class);
 
         doThrow(blobStorageException).when(leaseClient).releaseLease();
 
         // when
-        var exc = catchThrowable(() -> leaseAcquirer.ifAcquired(blobClient, onSuccess));
+        var exc = catchThrowable(() -> leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure));
 
         // then
         assertThat(exc).isNull();
-        verify(onSuccess).run();
-
+        verify(onSuccess).accept(null);
+        verify(onFailure, never()).accept(any(BlobErrorCode.class));
         verify(leaseClient).releaseLease();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    void should_run_custom_function_when_blob_not_found() {
-        // given
-        var onSuccess = mock(Consumer.class);
-        var onBlobNotFound = mock(Runnable.class);
-        doThrow(blobStorageException).when(leaseClient).acquireLease(LEASE_DURATION_IN_SECONDS);
-        when(blobStorageException.getErrorCode()).thenReturn(BLOB_NOT_FOUND);
-
-        // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onBlobNotFound);
-
-        // then
-        verify(onSuccess, never()).accept(anyString());
-        verify(onBlobNotFound).run();
-        verify(leaseClient, never()).releaseLease();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Acquire lease on blobs before deleting them](https://tools.hmcts.net/jira/browse/BPS-1205)

### Change description ###

Rolling back some of the changes introduced in #546. This way it'll be as before the refactor. Changing `onFailure` to `Consumer` though and including error code into log entry so the reason is clear.

This will provide exact detail for another PR (#551) I seem to not able to get the detail here locally

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
