### PR TITLE
Do not release lease for deleted blobs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -25,6 +25,12 @@ public class LeaseAcquirer {
         this.leaseClientProvider = leaseClientProvider;
     }
 
+    /**
+     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform deletion task.
+     * @param blobClient Represents blob
+     * @param onSuccess Runnable task to perform when lease is acquired
+     * @param onFailure Extra step to execute in case an error occurred
+     */
     public void processAndRelease(BlobClient blobClient, Runnable onSuccess, Consumer<BlobErrorCode> onFailure) {
         var leaseClient = ifAcquiredOrElse(blobClient, leaseId -> onSuccess.run(), onFailure);
 
@@ -34,7 +40,7 @@ public class LeaseAcquirer {
     }
 
     /**
-     * Main wrapper for blobs to be leased by {@link BlobLeaseClient}.
+     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform non-delete task.
      * @param blobClient Represents blob
      * @param onSuccess Consumer which takes in {@code leaseId} acquired with {@link BlobLeaseClient}
      * @param onFailure Extra step to execute in case an error occurred

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -26,7 +26,7 @@ public class LeaseAcquirer {
     }
 
     /**
-     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform deletion task.
+     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform non-delete task.
      * @param blobClient Represents blob
      * @param onSuccess Runnable task to perform when lease is acquired
      * @param onFailure Extra step to execute in case an error occurred
@@ -40,7 +40,7 @@ public class LeaseAcquirer {
     }
 
     /**
-     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform non-delete task.
+     * Main wrapper for blobs to be leased by {@link BlobLeaseClient} and perform deletion task.
      * @param blobClient Represents blob
      * @param onSuccess Consumer which takes in {@code leaseId} acquired with {@link BlobLeaseClient}
      * @param onFailure Extra step to execute in case an error occurred

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerCleaner.java
@@ -65,7 +65,8 @@ public class ContainerCleaner {
                     blobClient.getContainerName(),
                     errorCode
                 );
-            }
+            },
+            false
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -88,15 +88,16 @@ public class ContainerProcessor {
     }
 
     private void leaseAndThen(BlobClient blobClient, Runnable action) {
-        leaseAcquirer.processAndRelease(
+        leaseAcquirer.ifAcquiredOrElse(
             blobClient,
-            action,
+            leaseId -> action.run(),
             errorCode -> logger.info(
                 "Cannot acquire a lease for blob - skipping. File name: {}, container: {}, error code: {}",
                 blobClient.getBlobName(),
                 blobClient.getContainerName(),
                 errorCode
-            )
+            ),
+            true
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -88,9 +88,9 @@ public class ContainerProcessor {
     }
 
     private void leaseAndThen(BlobClient blobClient, Runnable action) {
-        leaseAcquirer.ifAcquiredOrElse(
+        leaseAcquirer.processAndRelease(
             blobClient,
-            leaseId -> action.run(),
+            action,
             errorCode -> logger.info(
                 "Cannot acquire a lease for blob - skipping. File name: {}, container: {}, error code: {}",
                 blobClient.getBlobName(),

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/RejectedContainerCleaner.java
@@ -66,7 +66,8 @@ public class RejectedContainerCleaner {
             .forEach(blobClient -> leaseAcquirer.ifAcquiredOrElse(
                 blobClient,
                 leaseId -> delete(blobClient, leaseId),
-                errorCode -> {} // nothing to do if blob not found in rejected container
+                errorCode -> {}, // nothing to do if blob not found in rejected container
+                false
             ));
 
         logger.info("Finished removing rejected files. Container: {}", containerName);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirerTest.java
@@ -42,7 +42,7 @@ class LeaseAcquirerTest {
         var onFailure = mock(Consumer.class);
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure, false);
 
         // then
         verify(onSuccess).accept(null);
@@ -58,7 +58,7 @@ class LeaseAcquirerTest {
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
         // when
-        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure);
+        leaseAcquirer.ifAcquiredOrElse(blobClient, onSuccess, onFailure, false);
 
         // then
         verify(onSuccess, never()).accept(anyString());
@@ -71,7 +71,7 @@ class LeaseAcquirerTest {
         doThrow(blobStorageException).when(leaseClient).acquireLease(anyInt());
 
         // when
-        leaseAcquirer.processAndRelease(blobClient, mock(Runnable.class), mock(Consumer.class));
+        leaseAcquirer.ifAcquiredOrElse(blobClient, mock(Consumer.class), mock(Consumer.class), true);
 
         // then
         verify(leaseClient, never()).releaseLease();
@@ -80,7 +80,7 @@ class LeaseAcquirerTest {
     @Test
     void should_call_release_when_successfully_processed_blob() {
         // when
-        leaseAcquirer.processAndRelease(blobClient, mock(Runnable.class), mock(Consumer.class));
+        leaseAcquirer.ifAcquiredOrElse(blobClient, mock(Consumer.class), mock(Consumer.class), true);
 
         // then
         verify(leaseClient).releaseLease();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -139,10 +139,10 @@ class ContainerProcessorTest {
     @SuppressWarnings("unchecked")
     private void leaseCanBeAcquired() {
         doAnswer(invocation -> {
-            var okAction = (Consumer) invocation.getArgument(1);
-            okAction.accept(UUID.randomUUID().toString());
+            var okAction = (Runnable) invocation.getArgument(1);
+            okAction.run();
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any());
+        }).when(leaseAcquirer).processAndRelease(any(), any(), any());
     }
 
     @SuppressWarnings("unchecked")
@@ -151,7 +151,7 @@ class ContainerProcessorTest {
             var failureAction = (Consumer) invocation.getArgument(2);
             failureAction.accept(BlobErrorCode.INVALID_INPUT);
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any());
+        }).when(leaseAcquirer).processAndRelease(any(), any(), any());
     }
 
     private Envelope envelope(Status status) {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import static java.time.Instant.now;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -139,10 +140,10 @@ class ContainerProcessorTest {
     @SuppressWarnings("unchecked")
     private void leaseCanBeAcquired() {
         doAnswer(invocation -> {
-            var okAction = (Runnable) invocation.getArgument(1);
-            okAction.run();
+            var okAction = (Consumer) invocation.getArgument(1);
+            okAction.accept(UUID.randomUUID().toString());
             return null;
-        }).when(leaseAcquirer).processAndRelease(any(), any(), any());
+        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any(), anyBoolean());
     }
 
     @SuppressWarnings("unchecked")
@@ -151,7 +152,7 @@ class ContainerProcessorTest {
             var failureAction = (Consumer) invocation.getArgument(2);
             failureAction.accept(BlobErrorCode.INVALID_INPUT);
             return null;
-        }).when(leaseAcquirer).processAndRelease(any(), any(), any());
+        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any(), anyBoolean());
     }
 
     private Envelope envelope(Status status) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Acquire lease before deleting blob](https://tools.hmcts.net/jira/browse/BPS-1205)

### Change description ###

Deleting blob with lease it destroys it on the fly. Basically we don't need to make extra call to release the lease as blob is already deleted. Trace from app insights:

| Key | Value |
| ----- | -------- |
| BlobStorageException | Status code 404, "&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;Error&gt;&lt;Code&gt;BlobNotFound&lt;/Code&gt;&lt;Message&gt;The specified blob does not exist.<br>RequestId:2f53686c-601e-0004-71fb-42563d000000<br>Time:2020-06-15T10:00:00.5210724Z&lt;/Message&gt;&lt;/Error&gt;" |
| Logger Message | Could not release the lease with ID 486de9d0-c07b-451d-8223-d0f2d1161ca7. Blob: 2016704010065_15-06-2020-09-48-18.zip, container: probate |
| LoggerName | uk.gov.hmcts.reform.blobrouter.services.storage.LeaseAcquirer |
| LoggingLevel | WARN |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
