### PR TITLE
Fix envelopes datetime fields format with Local timezone

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -71,7 +71,7 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data", hasSize(1)))
             .andExpect(jsonPath("$.data[0].id").value(envelopeInDb.id.toString()))
-            .andExpect(jsonPath("$.data[0].created_at").value("2020-05-20 10:15:10"))
+            .andExpect(jsonPath("$.data[0].created_at").value("2020-05-20T10:15:10"))
             .andExpect(jsonPath("$.data[0].file_created_at").value(
                 toLocalTimeZone(envelopeInDb.fileCreatedAt))
             )

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/DateTimeUtils.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/DateTimeUtils.java
@@ -20,7 +20,8 @@ public final class DateTimeUtils {
 
     public static String toLocalTimeZone(Instant instant) {
         if (instant != null) {
-            return formatter.format(ZonedDateTime.ofInstant(instant, EUROPE_LONDON_ZONE_ID));
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+            return dateTimeFormatter.format(ZonedDateTime.ofInstant(instant, EUROPE_LONDON_ZONE_ID));
         }
         return null;
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/DateTimeUtils.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/util/DateTimeUtils.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.blobrouter.util;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static uk.gov.hmcts.reform.blobrouter.util.TimeZones.EUROPE_LONDON_ZONE_ID;
@@ -17,9 +18,9 @@ public final class DateTimeUtils {
         return LocalDateTime.parse(string, formatter).atZone(EUROPE_LONDON_ZONE_ID).toInstant();
     }
 
-    public static Instant toLocalTimeZone(Instant instant) {
+    public static String toLocalTimeZone(Instant instant) {
         if (instant != null) {
-            return instant.atZone(EUROPE_LONDON_ZONE_ID).toInstant();
+            return formatter.format(ZonedDateTime.ofInstant(instant, EUROPE_LONDON_ZONE_ID));
         }
         return null;
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
@@ -73,7 +73,7 @@ public class EnvelopeController {
 
     private String toLocalTimeZone(Instant instant) {
         if (instant != null) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
             return formatter.format(ZonedDateTime.ofInstant(instant, EUROPE_LONDON_ZONE_ID));
         }
         return null;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeController.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -69,9 +71,10 @@ public class EnvelopeController {
         );
     }
 
-    private Instant toLocalTimeZone(Instant instant) {
+    private String toLocalTimeZone(Instant instant) {
         if (instant != null) {
-            return instant.atZone(EUROPE_LONDON_ZONE_ID).toInstant();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            return formatter.format(ZonedDateTime.ofInstant(instant, EUROPE_LONDON_ZONE_ID));
         }
         return null;
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeEventResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeEventResponse.java
@@ -2,15 +2,13 @@ package uk.gov.hmcts.reform.blobrouter.model.out;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.Instant;
-
 public class EnvelopeEventResponse {
 
     @JsonProperty("id")
     public final long id;
 
     @JsonProperty("created_at")
-    public final Instant createdAt;
+    public final String createdAt;
 
     @JsonProperty("event")
     public final String event;
@@ -18,7 +16,7 @@ public class EnvelopeEventResponse {
     @JsonProperty("notes")
     public final String notes;
 
-    public EnvelopeEventResponse(long id, Instant createdAt, String event, String notes) {
+    public EnvelopeEventResponse(long id, String createdAt, String event, String notes) {
         this.id = id;
         this.createdAt = createdAt;
         this.event = event;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/EnvelopeInfo.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.blobrouter.model.out;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.blobrouter.data.envelopes.Status;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,13 +18,13 @@ public class EnvelopeInfo {
     public final String fileName;
 
     @JsonProperty("created_at")
-    public final Instant createdAt;
+    public final String createdAt;
 
     @JsonProperty("file_created_at")
-    public final Instant fileCreatedAt;
+    public final String fileCreatedAt;
 
     @JsonProperty("dispatched_at")
-    public final Instant dispatchedAt;
+    public final String dispatchedAt;
 
     @JsonProperty("status")
     public final Status status;
@@ -43,9 +42,9 @@ public class EnvelopeInfo {
         UUID id,
         String container,
         String fileName,
-        Instant createdAt,
-        Instant fileCreatedAt,
-        Instant dispatchedAt,
+        String createdAt,
+        String fileCreatedAt,
+        String dispatchedAt,
         Status status,
         boolean isDeleted,
         boolean pendingNotification,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1260


### Change description ###
Date time fields in the `/envelopes` endpoint still return in UTC format. 
Use `DatetimeFormatter` to format the values properly.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
