### PR TITLE
Publish notification queue message with envelope id

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
@@ -50,6 +50,9 @@ class NotificationServiceTest {
     @Captor
     private ArgumentCaptor<NotificationMsg> notificationMsgCaptor;
 
+    @Captor
+    private ArgumentCaptor<String> messageIdCaptor;
+
     @Mock
     NotificationsPublisher notificationsPublisher;
 
@@ -87,7 +90,7 @@ class NotificationServiceTest {
         notificationService.sendNotifications();
 
         // then
-        verify(notificationsPublisher, times(2)).publish(any());
+        verify(notificationsPublisher, times(2)).publish(any(), any());
 
         Optional<Envelope> envelope1 = envelopeService.findEnvelope(envelopeId1);
         assertThat(envelope1).hasValueSatisfying(env -> assertThat(env.pendingNotification).isFalse());
@@ -123,12 +126,14 @@ class NotificationServiceTest {
         notificationService.sendNotifications(); //1st time
         notificationService.sendNotifications(); //2nd time
 
-        verify(notificationsPublisher).publish(notificationMsgCaptor.capture());
-        verify(notificationsPublisher, times(1)).publish(any()); // message published only once
+        verify(notificationsPublisher).publish(notificationMsgCaptor.capture(), messageIdCaptor.capture());
+        verify(notificationsPublisher, times(1)).publish(any(), any()); // message published only once
 
         NotificationMsg msgCaptorValue = notificationMsgCaptor.getValue();
+        String messageId = messageIdCaptor.getValue();
         assertThat(msgCaptorValue.zipFileName).isEqualTo("blob3.zip");
         assertThat(msgCaptorValue.container).isEqualTo("bulkscan");
+        assertThat(messageId).isEqualTo(envelopeId3.toString());
 
         Optional<Envelope> envelope3 = envelopeService.findEnvelope(envelopeId3);
         assertThat(envelope3).hasValueSatisfying(env -> assertThat(env.pendingNotification).isFalse());

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisher.java
@@ -9,8 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.blobrouter.servicebus.notifications.model.NotificationMsg;
 
-import java.util.UUID;
-
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Service
@@ -29,12 +27,12 @@ public class NotificationsPublisher {
         this.objectMapper = objectMapper;
     }
 
-    public void publish(NotificationMsg notificationMsg) {
+    public void publish(NotificationMsg notificationMsg, String messageId) {
         try {
             String messageBody = objectMapper.writeValueAsString(notificationMsg);
 
             IMessage message = new Message(
-                UUID.randomUUID().toString(),
+                messageId,
                 messageBody,
                 APPLICATION_JSON_VALUE
             );
@@ -50,9 +48,10 @@ public class NotificationsPublisher {
         } catch (Exception ex) {
             throw new NotificationsPublishingException(
                 String.format(
-                    "An error occurred when trying to publish notification for File name: %s, Container: %s",
+                    "An error occurred when trying to publish notification for File name: %s, Container: %s, Id: %s",
                     notificationMsg.zipFileName,
-                    notificationMsg.container
+                    notificationMsg.container,
+                    messageId
                 ),
                 ex
             );

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/NotificationService.java
@@ -40,7 +40,7 @@ public class NotificationService {
                 log.info(
                     "Send message to notifications queue. File name: {} Container: {}", env.fileName, env.container
                 );
-                notificationsPublisher.publish(mapToNotificationMessage(env));
+                notificationsPublisher.publish(mapToNotificationMessage(env), env.envelopeId.toString());
                 envelopeService.markPendingNotificationAsSent(env.envelopeId);
             }
         );

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/servicebus/notifications/NotificationsPublisherTest.java
@@ -51,7 +51,7 @@ class NotificationsPublisherTest {
         );
 
         // when
-        notifier.publish(notificationMsg);
+        notifier.publish(notificationMsg, "messageId");
 
         // then
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -73,6 +73,7 @@ class NotificationsPublisherTest {
             notificationMsg.service
         );
         JSONAssert.assertEquals(expectedMessageBodyJson, messageBodyJson, JSONCompareMode.LENIENT);
+        assertThat(message.getMessageId()).isEqualTo("messageId");
     }
 
     @Test
@@ -89,15 +90,14 @@ class NotificationsPublisherTest {
 
         // when
         Throwable exc = catchThrowable(
-            () -> notifier.publish(notificationMsg)
+            () -> notifier.publish(notificationMsg, "id1")
         );
 
         // then
         assertThat(exc)
             .isInstanceOf(NotificationsPublishingException.class)
             .hasMessage(
-                "An error occurred when trying to publish notification for "
-                    + "File name: A.zip, Container: C1"
+                "An error occurred when trying to publish notification for File name: A.zip, Container: C1, Id: id1"
             ).hasCause(exceptionToThrow);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/NotificationServiceTest.java
@@ -57,7 +57,7 @@ class NotificationServiceTest {
 
         // then
         verify(rejectedEnvelopeRepository).getRejectedEnvelopes();
-        verify(notificationsPublisher, times(2)).publish(any(NotificationMsg.class));
+        verify(notificationsPublisher, times(2)).publish(any(NotificationMsg.class), any());
         verify(envelopeService).markPendingNotificationAsSent(envelopeId1);
         verify(envelopeService).markPendingNotificationAsSent(envelopeId2);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1293


### Change description ###
In Blob Router, publish notification message to queue with envelope id as message id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
