### PR TITLE
Check status of the envelope before processing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/LeaseAcquirer.java
@@ -50,7 +50,7 @@ public class LeaseAcquirer {
 
     public void ifAcquiredOrElse(
         BlobClient blobClient,
-        Predicate<BlobClient> condition,
+        Predicate<BlobClient> blobCondition,
         Consumer<String> onSuccess,
         Consumer<BlobErrorCode> onFailure,
         boolean releaseLease
@@ -59,7 +59,7 @@ public class LeaseAcquirer {
             var leaseClient = leaseClientProvider.get(blobClient);
             var leaseId = leaseClient.acquireLease(LEASE_DURATION_IN_SECONDS);
 
-            if (condition.test(blobClient)) {
+            if (blobCondition.test(blobClient)) {
                 onSuccess.accept(leaseId);
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -93,8 +93,8 @@ public class ContainerProcessor {
             );
     }
 
-    private boolean isEnvelopeInCreatedStatus(BlobClient blob) {
-        Optional<Envelope> envelopeOpt = getLastEnvelope(blob);
+    private boolean isEnvelopeInCreatedStatus(BlobClient blobClient) {
+        Optional<Envelope> envelopeOpt = getLastEnvelope(blobClient);
         if (envelopeOpt.isPresent()) {
             if (envelopeOpt.get().status == Status.CREATED) {
                 return true;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -82,7 +82,7 @@ public class ContainerProcessor {
                     if (envelope.status == Status.CREATED) {
                         leaseAndThen(
                             blobClient,
-                            this::isEnvelopeInStatusCreated,
+                            this::isEnvelopeInCreatedStatus,
                             () -> blobProcessor.continueProcessing(envelope.id, blobClient)
                         );
                     } else {
@@ -93,7 +93,7 @@ public class ContainerProcessor {
             );
     }
 
-    private boolean isEnvelopeInStatusCreated(BlobClient blob) {
+    private boolean isEnvelopeInCreatedStatus(BlobClient blob) {
         Optional<Envelope> envelopeOpt = getLastEnvelope(blob);
         if (envelopeOpt.isPresent()) {
             if (envelopeOpt.get().status == Status.CREATED) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessor.java
@@ -53,7 +53,7 @@ public class ContainerProcessor {
                 .stream()
                 .filter(blobItem -> isReady(blobItem, containerName))
                 .map(blobItem -> containerClient.getBlobClient(blobItem.getName()))
-                .forEach(blob -> processBlob(blob));
+                .forEach(this::processBlob);
 
             logger.info("Finished processing container {}", containerName);
         } catch (Exception exception) {
@@ -114,10 +114,10 @@ public class ContainerProcessor {
         logger.info("Envelope already processed in system, skipping. {} ", envelope.getBasicInfo());
     }
 
-    private void leaseAndThen(BlobClient blobClient, Predicate<BlobClient> condition, Runnable action) {
+    private void leaseAndThen(BlobClient blobClient, Predicate<BlobClient> blobCondition, Runnable action) {
         leaseAcquirer.ifAcquiredOrElse(
             blobClient,
-            condition,
+            blobCondition,
             leaseId -> action.run(),
             errorCode -> logger.info(
                 "Cannot acquire a lease for blob - skipping. File name: {}, container: {}, error code: {}",

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/ContainerProcessorTest.java
@@ -140,10 +140,10 @@ class ContainerProcessorTest {
     @SuppressWarnings("unchecked")
     private void leaseCanBeAcquired() {
         doAnswer(invocation -> {
-            var okAction = (Consumer) invocation.getArgument(1);
+            var okAction = (Consumer) invocation.getArgument(2);
             okAction.accept(UUID.randomUUID().toString());
             return null;
-        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any(), anyBoolean());
+        }).when(leaseAcquirer).ifAcquiredOrElse(any(), any(), any(), any(), anyBoolean());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1321 (Blob router doesn't fetch envelope from DB after acquiring lease)


### Change description ###
Introduced predicate for checking if status of the envelope being processed is still CREATED and not changed due to any race condition.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
