### PR TITLE
Rescheduled daily report

### DIFF
--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-blob-router/values.yaml
+++ b/charts/reform-scan-blob-router/values.yaml
@@ -31,7 +31,7 @@ java:
     REJECT_DUPLICATES_CRON: "0/30 * * * * *"
     CHECK_NEW_ENVELOPES_CRON: "0 0 * * * *"
     TASK_SCAN_DELAY: "4000" # in millis
-    SEND_DAILY_REPORT_CRON: "0 0 18 ? * MON-FRI"
+    SEND_DAILY_REPORT_CRON: "0 0 6 ? * TUE-SAT"
     SEND_NOTIFICATIONS_CRON: "0 0/10 * * * *"
 
     STORAGE_URL: https://reformscan.{{ .Values.global.environment }}.platform.hmcts.net

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/SendDailyReportTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/tasks/SendDailyReportTask.java
@@ -61,7 +61,7 @@ public class SendDailyReportTask {
     public void sendReport() {
         logger.info("Started {} job", TASK_NAME);
 
-        final LocalDate reportDate = LocalDate.now();
+        final LocalDate reportDate = getPreviousDay();
 
         final List<EnvelopeSummaryItem> report = reportService.getDailyReport(reportDate);
 
@@ -84,6 +84,10 @@ public class SendDailyReportTask {
         }
 
         logger.info("Finished {} job", TASK_NAME);
+    }
+
+    private LocalDate getPreviousDay() {
+        return LocalDate.now().minusDays(1);
     }
 
     private String getReportAttachmentName(LocalDate reportDate) {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/SendDailyReportTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/SendDailyReportTaskTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -67,15 +66,13 @@ class SendDailyReportTaskTest {
 
         sendDailyReportTask = getSendDailyReportTask(from, recipients);
 
-        given(reportService.getDailyReport(any(LocalDate.class))).willReturn(report);
+        given(reportService.getDailyReport(getYesterday())).willReturn(report);
         given(reportCsvWriter.writeEnvelopesSummaryToCsv(report)).willReturn(reportFile);
 
         // when
         sendDailyReportTask.sendReport();
 
         // then
-        verify(reportService).getDailyReport(any(LocalDate.class));
-        verify(reportCsvWriter).writeEnvelopesSummaryToCsv(report);
         verify(emailSender).sendMessageWithAttachments(
             subjectCaptor.capture(),
             bodyCaptor.capture(),
@@ -109,15 +106,13 @@ class SendDailyReportTaskTest {
 
         sendDailyReportTask = getSendDailyReportTask(from, recipients);
 
-        given(reportService.getDailyReport(any(LocalDate.class))).willReturn(report);
+        given(reportService.getDailyReport(getYesterday())).willReturn(report);
         given(reportCsvWriter.writeEnvelopesSummaryToCsv(report)).willThrow(new IOException());
 
         // when
         sendDailyReportTask.sendReport();
 
         // then
-        verify(reportService).getDailyReport(any(LocalDate.class));
-        verify(reportCsvWriter).writeEnvelopesSummaryToCsv(report);
         verifyNoInteractions(emailSender);
     }
 
@@ -127,6 +122,10 @@ class SendDailyReportTaskTest {
             RuntimeException.class,
             () -> getSendDailyReportTask("From", new String[]{})
         );
+    }
+
+    private LocalDate getYesterday() {
+        return LocalDate.now().minusDays(1);
     }
 
     private SendDailyReportTask getSendDailyReportTask(String from, String[] recipients) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1367


### Change description 
The report rescheduled to run in the morning (6 am) next day to harvest data for the previous day. It is scheduled from Tuesday to Saturday to send data for week days.

Flux PR: https://github.com/hmcts/cnp-flux-config/pull/5331

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
