### PR TITLE
Remove no longer needed controller advice section for `EnvelopeNotFoundException`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptionhandler/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptionhandler/ResponseExceptionHandler.java
@@ -3,20 +3,16 @@ package uk.gov.hmcts.reform.blobrouter.exceptionhandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import uk.gov.hmcts.reform.blobrouter.exceptions.EnvelopeNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidRequestParametersException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidSupplierStatementException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceConfigNotFoundException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.ServiceDisabledException;
 import uk.gov.hmcts.reform.blobrouter.exceptions.UnableToGenerateSasTokenException;
 import uk.gov.hmcts.reform.blobrouter.model.out.ErrorResponse;
-
-import static org.springframework.http.ResponseEntity.notFound;
 
 @RestControllerAdvice
 public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
@@ -39,12 +35,6 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected ErrorResponse handleServiceDisabledException(ServiceDisabledException exception) {
         return new ErrorResponse(exception.getMessage(), exception.getClass());
-    }
-
-    @ExceptionHandler(EnvelopeNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    protected ResponseEntity<?> handleEnvelopeNotFoundException(EnvelopeNotFoundException exception) {
-        return notFound().build();
     }
 
     @ExceptionHandler(InvalidRequestParametersException.class)


### PR DESCRIPTION
### Change description ###

During tiny investigation done while reviewing runbooks noticed that this exception is not interfering with any controller activities - it is only present in scheduled tasks' processes. Therefore - custom controller advice is not needed for this exception.

P.S. sort of solves unnecessary use of `ResponseEntity` in this advice as it is already `RestControllerAdvice`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
