### PR TITLE
Add functional tests for reconciliation endpoint Authorization

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,6 +31,7 @@ def combinedSecrets = [
 
      secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
      secret('storage-account-staging-name', 'TEST_STORAGE_ACCOUNT_NAME'),
+     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY'),
    ]
  ]
 
@@ -45,7 +46,8 @@ def combinedSecrets = [
      secret('test-not-yet-valid-key-store', 'TEST_NOT_YET_VALID_KEY_STORE'),
      secret('test-not-yet-valid-key-store-password', 'TEST_NOT_YET_VALID_KEY_STORE_PASSWORD'),
 
-     secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY')
+     secret('test-subscription-key', 'TEST_SUBSCRIPTION_KEY'),
+     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY')
    ]
  ]
 
@@ -91,7 +93,6 @@ withPipeline(type, product, component) {
   env.TEST_STORAGE_ACCOUNT_URL = 'https://reformscanaatstaging.blob.core.windows.net'
   env.API_GATEWAY_URL = "https://core-api-mgmt-aat.azure-api.net/reform-scan"
   env.TEST_USE_PROXY_FOR_SOURCE_STORAGE = "false"
-  env.TEST_RECONCILIATION_API_KEY = "QzYzRUE5RjEtODc1RC00MTcwLTkzRjMtQjVEMjNEQjEwQkUz"
 
   before('smoketest:preview') {
      withAksClient('nonprod', product) {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,7 +31,6 @@ def combinedSecrets = [
 
      secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
      secret('storage-account-staging-name', 'TEST_STORAGE_ACCOUNT_NAME'),
-     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY'),
    ]
  ]
 
@@ -109,6 +108,9 @@ withPipeline(type, product, component) {
       env.TEST_STORAGE_ACCOUNT_NAME = previewAccountName(kubectl, storageSecret, namespace)
       env.TEST_STORAGE_ACCOUNT_URL = "https://${env.TEST_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
       env.TEST_STORAGE_ACCOUNT_KEY = previewAccountKey(kubectl, storageSecret, namespace)
+
+      // Get reconciliation api key
+      env.TEST_RECONCILIATION_API_KEY = previewAccountKey(kubectl, "reconciliation-api-key", namespace)
     }
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -91,6 +91,7 @@ withPipeline(type, product, component) {
   env.TEST_STORAGE_ACCOUNT_URL = 'https://reformscanaatstaging.blob.core.windows.net'
   env.API_GATEWAY_URL = "https://core-api-mgmt-aat.azure-api.net/reform-scan"
   env.TEST_USE_PROXY_FOR_SOURCE_STORAGE = "false"
+  env.TEST_RECONCILIATION_API_KEY = "QzYzRUE5RjEtODc1RC00MTcwLTkzRjMtQjVEMjNEQjEwQkUz"
 
   before('smoketest:preview') {
      withAksClient('nonprod', product) {
@@ -108,9 +109,6 @@ withPipeline(type, product, component) {
       env.TEST_STORAGE_ACCOUNT_NAME = previewAccountName(kubectl, storageSecret, namespace)
       env.TEST_STORAGE_ACCOUNT_URL = "https://${env.TEST_STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
       env.TEST_STORAGE_ACCOUNT_KEY = previewAccountKey(kubectl, storageSecret, namespace)
-
-      // Get reconciliation api key
-      env.TEST_RECONCILIATION_API_KEY = previewAccountKey(kubectl, "reconciliation-api-key", namespace)
     }
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,6 +31,7 @@ def combinedSecrets = [
 
      secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
      secret('storage-account-staging-name', 'TEST_STORAGE_ACCOUNT_NAME'),
+     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY'),
    ]
  ]
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,7 +31,7 @@ def combinedSecrets = [
 
      secret('storage-account-staging-secondary-key', 'TEST_STORAGE_ACCOUNT_KEY'),
      secret('storage-account-staging-name', 'TEST_STORAGE_ACCOUNT_NAME'),
-     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY'),
+     secret('reconciliation-api-key', 'TEST_RECONCILIATION_API_KEY')
    ]
  ]
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
@@ -53,7 +53,6 @@ public class ReconciliationControllerTest {
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Blob Router Service Functional test")
             .header(HttpHeaders.AUTHORIZATION, authKey)
             .body(report)
-            .body(report)
             .post("/reform-scan/reconciliation-report/{date}", LocalDate.now())
             .then()
             .statusCode(expectedStatus);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
@@ -53,7 +53,7 @@ public class ReconciliationControllerTest {
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Blob Router Service Functional test")
             .header(HttpHeaders.AUTHORIZATION, authKey)
             .body(report)
-            .post("/reform-scan/reconciliation-report/{date}", LocalDate.now())
+            .post("/reform-scan/reconciliation-report/{date}", LocalDate.now().toString())
             .then()
             .statusCode(expectedStatus);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.blobrouter.config.TestConfiguration;
+import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -49,8 +50,9 @@ public class ReconciliationControllerTest {
             .relaxedHTTPSValidation()
             .baseUri(config.blobRouterUrl)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(report)
+            .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Blob Router Service Functional test")
             .header(HttpHeaders.AUTHORIZATION, authKey)
+            .body(report)
             .body(report)
             .post("/reform-scan/reconciliation-report/{date}", LocalDate.now())
             .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationControllerTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.blobrouter;
+
+import com.google.common.io.Resources;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import uk.gov.hmcts.reform.blobrouter.config.TestConfiguration;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static com.google.common.io.Resources.getResource;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+public class ReconciliationControllerTest {
+
+    private static final TestConfiguration config = new TestConfiguration();
+
+    @Test
+    void should_return_success_response_when_authorization_key_is_valid() throws Exception {
+        // given
+        String validAuthKey = "Bearer " + config.reconciliationApiKey;
+
+        // then
+        postReconciliationSupplierReport(validAuthKey, OK.value());
+    }
+
+    @Test
+    void should_return_unauthorized_response_when_authorization_key_is_invalid() throws Exception {
+        // given
+        String invalidAuthKey = "Bearer " + UUID.randomUUID().toString();
+
+        // then
+        postReconciliationSupplierReport(invalidAuthKey, UNAUTHORIZED.value());
+    }
+
+    private void postReconciliationSupplierReport(String authKey, int expectedStatus) throws IOException {
+        String report = Resources.toString(
+            getResource("reconciliation/reconciliation-supplier-report.json"),
+            UTF_8
+        );
+
+        RestAssured
+            .given()
+            .relaxedHTTPSValidation()
+            .baseUri(config.blobRouterUrl)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(report)
+            .header(HttpHeaders.AUTHORIZATION, authKey)
+            .body(report)
+            .post("/reform-scan/reconciliation-report/{date}", LocalDate.now())
+            .then()
+            .statusCode(expectedStatus);
+    }
+
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/config/TestConfiguration.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/blobrouter/config/TestConfiguration.java
@@ -7,6 +7,8 @@ public class TestConfiguration {
 
     public final String blobRouterUrl;
 
+    public final String reconciliationApiKey;
+
     public final String sourceStorageAccountName;
     public final String sourceStorageAccountKey;
     public final String sourceStorageAccountUrl;
@@ -17,6 +19,7 @@ public class TestConfiguration {
         Config config = ConfigFactory.load();
 
         this.blobRouterUrl = config.getString("blob-router-url");
+        this.reconciliationApiKey = config.getString("reconciliation-api-key");
         this.sourceStorageAccountName = config.getString("source-storage-account-name");
         this.sourceStorageAccountKey = config.getString("source-storage-account-key");
         this.sourceStorageAccountUrl = config.getString("source-storage-account-url");

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -1,5 +1,7 @@
 blob-router-url=${TEST_URL}
 
+reconciliation-api-key=${TEST_RECONCILIATION_API_KEY}
+
 source-storage-account-name=${TEST_STORAGE_ACCOUNT_NAME}
 source-storage-account-key=${TEST_STORAGE_ACCOUNT_KEY}
 source-storage-account-url=${TEST_STORAGE_ACCOUNT_URL}

--- a/src/functionalTest/resources/reconciliation/reconciliation-supplier-report.json
+++ b/src/functionalTest/resources/reconciliation/reconciliation-supplier-report.json
@@ -1,0 +1,20 @@
+{
+  "report": {
+    "envelopes": [
+      {
+        "zip_file_name": "1010404021234_14-08-2020-03-06-18.zip",
+        "rescan_for": null,
+        "container": "bulkscan",
+        "jurisdiction": "BULKSCAN",
+        "scannable_item_dcns": [
+          "1015404021234",
+          "1015404021235"
+        ],
+        "payment_dcns": [
+          "123123",
+          "123124"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1360


### Change description ###
Add functional tests for Reconciliation endpoint authorization. 
Scenarios:
- Authorization header with **valid** API Key (should return 200)
- Authorization header with **invalid** API key (should return 401)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
