### PR TITLE
Update Swagger configuration to publish reconciliation api

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/SwaggerConfiguration.java
@@ -7,7 +7,6 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-import uk.gov.hmcts.reform.blobrouter.Application;
 
 @Configuration
 @EnableSwagger2
@@ -18,7 +17,7 @@ public class SwaggerConfiguration {
         return new Docket(DocumentationType.SWAGGER_2)
             .useDefaultResponseMessages(false)
             .select()
-            .apis(RequestHandlerSelectors.basePackage(Application.class.getPackage().getName() + ".controllers"))
+            .apis(RequestHandlerSelectors.any())
             .paths(PathSelectors.any())
             .build();
     }


### PR DESCRIPTION
### Change description ###
Swagger is not publishing Reconciliation API because the controller is in `uk.gov.hmcts.reform.blobrouter.reconciliation.controller`. 

see https://hmcts.github.io/reform-api-docs/specs/blob-router-service.json

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
