### PR TITLE
Update Unauthorized error response in Reconciliation endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationControllerTest.java
@@ -8,13 +8,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidApiKeyException;
 
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationControllerTest.java
@@ -58,7 +58,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
         );
 
         // when
-        MvcResult result = mockMvc
+        mockMvc
             .perform(
                 post(RECONCILIATION_URL)
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -66,10 +66,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
             )
             .andDo(print())
             .andExpect(status().isUnauthorized())
-            .andReturn();
-
-        assertThat(result.getResolvedException()).isExactlyInstanceOf(InvalidApiKeyException.class);
-        assertThat(result.getResolvedException().getMessage()).isEqualTo("API Key is missing");
+            .andExpect(MockMvcResultMatchers.content().string("API Key is missing"));
     }
 
     @Test
@@ -81,7 +78,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
         );
 
         // when
-        MvcResult result = mockMvc
+        mockMvc
             .perform(
                 post(RECONCILIATION_URL)
                     .header(HttpHeaders.AUTHORIZATION, "valid-api-key")
@@ -90,10 +87,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
             )
             .andDo(print())
             .andExpect(status().isUnauthorized())
-            .andReturn();
-
-        assertThat(result.getResolvedException()).isExactlyInstanceOf(InvalidApiKeyException.class);
-        assertThat(result.getResolvedException().getMessage()).isEqualTo("Invalid API Key");
+            .andExpect(MockMvcResultMatchers.content().string("Invalid API Key"));
     }
 
     @Test
@@ -105,7 +99,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
         );
 
         // when
-        MvcResult result = mockMvc
+        mockMvc
             .perform(
                 post(RECONCILIATION_URL)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-api-key")
@@ -114,10 +108,7 @@ public class ReconciliationControllerTest extends ControllerTestBase {
             )
             .andDo(print())
             .andExpect(status().isUnauthorized())
-            .andReturn();
-
-        assertThat(result.getResolvedException()).isExactlyInstanceOf(InvalidApiKeyException.class);
-        assertThat(result.getResolvedException().getMessage()).isEqualTo("Invalid API Key");
+            .andExpect(MockMvcResultMatchers.content().string("Invalid API Key"));
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptionhandler/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/exceptionhandler/ResponseExceptionHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.blobrouter.exceptionhandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -51,10 +52,9 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidApiKeyException.class)
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    protected ErrorResponse handleInvalidApiKeyException(InvalidApiKeyException exception) {
+    protected ResponseEntity<String> handleInvalidApiKeyException(InvalidApiKeyException exception) {
         log.error(exception.getMessage(), exception);
-        return new ErrorResponse(exception.getMessage(), exception.getClass());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exception.getMessage());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
### Change description ###
When the authorization header is invalid, the Reconciliation endpoint returns the response with the error message and cause. 
Updated the Exception handler to return the error message only.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
