### PR TITLE
Update SAS token caching to support multiple storage accounts

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientBuilderProvider;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProxy;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
-import uk.gov.hmcts.reform.blobrouter.services.storage.BulkScanSasTokenCache;
+import uk.gov.hmcts.reform.blobrouter.services.storage.SasTokenCache;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.io.ByteArrayInputStream;
@@ -54,7 +54,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
         containerClientProvider = new BlobContainerClientProxy(
             mock(BlobContainerClient.class),
             blobContainerClientBuilderProvider,
-            mock(BulkScanSasTokenCache.class)
+            mock(SasTokenCache.class)
         );
         dbHelper.deleteAll();
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
@@ -27,12 +27,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
 
 @ExtendWith(MockitoExtension.class)
 public class BlobContainerClientProxyTest {
 
     @Mock BlobContainerClient crimeClient;
-    @Mock BulkScanSasTokenCache bulkScanSasTokenCache;
+    @Mock SasTokenCache sasTokenCache;
     @Mock BlobContainerClientBuilder blobContainerClientBuilder;
     @Mock BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
 
@@ -53,7 +54,7 @@ public class BlobContainerClientProxyTest {
         this.blobContainerClientProxy = new BlobContainerClientProxy(
             crimeClient,
             blobContainerClientBuilderProvider,
-            bulkScanSasTokenCache
+            sasTokenCache
         );
     }
 
@@ -87,13 +88,13 @@ public class BlobContainerClientProxyTest {
 
         assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
 
-        verify(bulkScanSasTokenCache, never()).getSasToken(containerName);
+        verify(sasTokenCache, never()).getSasToken(BULKSCAN, containerName);
     }
 
     @Test
     void should_upload_to_bulk_scan_storage_when_target_storage_bulk_scan() {
 
-        given(bulkScanSasTokenCache.getSasToken(any())).willReturn("token1");
+        given(sasTokenCache.getSasToken(any(), any())).willReturn("token1");
 
         given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
             .willReturn(blobContainerClientBuilder);
@@ -109,10 +110,10 @@ public class BlobContainerClientProxyTest {
             blobName,
             blobContent,
             containerName,
-            TargetStorageAccount.BULKSCAN
+            BULKSCAN
         );
 
-        verify(bulkScanSasTokenCache).getSasToken(containerName);
+        verify(sasTokenCache).getSasToken(BULKSCAN, containerName);
 
         // then
         ArgumentCaptor<ByteArrayInputStream> data = ArgumentCaptor.forClass(ByteArrayInputStream.class);
@@ -132,7 +133,7 @@ public class BlobContainerClientProxyTest {
 
         assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
 
-        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+        verify(sasTokenCache, never()).removeFromCache(BULKSCAN, containerName);
 
     }
 
@@ -152,11 +153,11 @@ public class BlobContainerClientProxyTest {
                 blobName,
                 blobContent,
                 containerName,
-                TargetStorageAccount.BULKSCAN
+                BULKSCAN
             )
         ).isInstanceOf(BlobStorageException.class);
 
-        verify(bulkScanSasTokenCache).removeFromCache(containerName);
+        verify(sasTokenCache).removeFromCache(BULKSCAN, containerName);
 
     }
 
@@ -176,7 +177,7 @@ public class BlobContainerClientProxyTest {
             )
         ).isInstanceOf(BlobStorageException.class);
 
-        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+        verify(sasTokenCache, never()).removeFromCache(BULKSCAN, containerName);
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.blobrouter.clients.bulkscanprocessor.BulkScanProcessorClient;
 import uk.gov.hmcts.reform.blobrouter.clients.response.SasTokenResponse;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.exceptions.InvalidSasTokenException;
 
 import java.time.OffsetDateTime;
@@ -21,18 +22,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class BulkScanSasTokenCacheTest {
+class SasTokenCacheTest {
 
     @Mock
     private BulkScanProcessorClient bulkScanProcessorClient;
 
-    private BulkScanSasTokenCache bulkScanContainerClientCache;
+    private SasTokenCache bulkScanContainerClientCache;
 
     private long refreshSasBeforeExpiry = 30;
 
     @BeforeEach
     private void setUp() {
-        this.bulkScanContainerClientCache = new BulkScanSasTokenCache(
+        this.bulkScanContainerClientCache = new SasTokenCache(
             bulkScanProcessorClient,
             refreshSasBeforeExpiry
         );
@@ -47,7 +48,7 @@ class BulkScanSasTokenCacheTest {
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
         String sasToken =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
         assertThat(sasToken).isEqualTo(token);
         verify(bulkScanProcessorClient).getSasToken(containerName);
@@ -61,7 +62,7 @@ class BulkScanSasTokenCacheTest {
 
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
-        assertThatThrownBy(() -> bulkScanContainerClientCache.getSasToken(containerName))
+        assertThatThrownBy(() -> bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName))
             .isInstanceOf(InvalidSasTokenException.class)
             .hasMessageContaining("Invalid SAS, the SAS expiration time parameter not found.");
     }
@@ -78,12 +79,12 @@ class BulkScanSasTokenCacheTest {
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
         String sasToken =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
         assertThat(sasToken).isNotNull();
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
         assertThat(sasToken).isSameAs(sasToken2);
         verify(bulkScanProcessorClient, times(1)).getSasToken(containerName);
@@ -108,10 +109,10 @@ class BulkScanSasTokenCacheTest {
             .willReturn(sasTokenResponse1).willReturn(sasTokenResponse2);
 
         String sasToken1 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
         assertThat(sasToken1).isNotNull();
         assertThat(sasToken2).isNotNull();
 
@@ -134,12 +135,12 @@ class BulkScanSasTokenCacheTest {
             .willReturn(new SasTokenResponse(token1), new SasTokenResponse(token2));
 
         String sasToken1 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
-        bulkScanContainerClientCache.removeFromCache(containerName);
+        bulkScanContainerClientCache.removeFromCache(TargetStorageAccount.BULKSCAN, containerName);
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            bulkScanContainerClientCache.getSasToken(TargetStorageAccount.BULKSCAN, containerName);
 
         assertThat(sasToken1).isEqualTo(token1);
         assertThat(sasToken2).isEqualTo(token2);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1377


### Change description ###
At the moment, only Bulkscan containers' sas tokens are cached. 
Update the config to cache sas token for multiple storage accounts.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
