### PR TITLE
Rename Bulkscan SAS token cache class

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.blobrouter.services.EnvelopeService;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientBuilderProvider;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobContainerClientProxy;
 import uk.gov.hmcts.reform.blobrouter.services.storage.BlobDispatcher;
-import uk.gov.hmcts.reform.blobrouter.services.storage.BulkScanSasTokenCache;
+import uk.gov.hmcts.reform.blobrouter.services.storage.SasTokenCache;
 import uk.gov.hmcts.reform.blobrouter.util.BlobStorageBaseTest;
 
 import java.io.ByteArrayInputStream;
@@ -54,7 +54,7 @@ class BlobProcessorTest extends BlobStorageBaseTest {
         containerClientProvider = new BlobContainerClientProxy(
             mock(BlobContainerClient.class),
             blobContainerClientBuilderProvider,
-            mock(BulkScanSasTokenCache.class)
+            mock(SasTokenCache.class)
         );
         dbHelper.deleteAll();
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
@@ -22,18 +22,18 @@ public class BlobContainerClientProxy {
 
     private final BlobContainerClient crimeClient;
     private final BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
-    private final BulkScanSasTokenCache bulkScanSasTokenCache;
+    private final SasTokenCache sasTokenCache;
 
     private static final Duration UPLOAD_TIMEOUT = Duration.ofSeconds(40);
 
     public BlobContainerClientProxy(
         @Qualifier("crime-storage-client") BlobContainerClient crimeClient,
         BlobContainerClientBuilderProvider blobContainerClientBuilderProvider,
-        BulkScanSasTokenCache bulkScanSasTokenCache
+        SasTokenCache sasTokenCache
     ) {
         this.crimeClient = crimeClient;
         this.blobContainerClientBuilderProvider = blobContainerClientBuilderProvider;
-        this.bulkScanSasTokenCache = bulkScanSasTokenCache;
+        this.sasTokenCache = sasTokenCache;
     }
 
     private BlobContainerClient get(TargetStorageAccount targetStorageAccount, String containerName) {
@@ -41,7 +41,7 @@ public class BlobContainerClientProxy {
             case BULKSCAN:
                 return blobContainerClientBuilderProvider
                     .getBlobContainerClientBuilder()
-                    .sasToken(bulkScanSasTokenCache.getSasToken(containerName))
+                    .sasToken(sasTokenCache.getSasToken(containerName))
                     .containerName(containerName)
                     .buildClient();
             case CRIME:
@@ -91,7 +91,7 @@ public class BlobContainerClientProxy {
             );
             if (targetStorageAccount == TargetStorageAccount.BULKSCAN
                 && HttpStatus.valueOf(ex.getResponse().getStatusCode()).is4xxClientError()) {
-                bulkScanSasTokenCache.removeFromCache(destinationContainer);
+                sasTokenCache.removeFromCache(destinationContainer);
             }
             throw ex;
         }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
@@ -24,16 +24,16 @@ import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Service
-public class BulkScanSasTokenCache {
+public class SasTokenCache {
 
-    private static final Logger logger = getLogger(BulkScanSasTokenCache.class);
+    private static final Logger logger = getLogger(SasTokenCache.class);
     private final BulkScanProcessorClient bulkScanSasTokenClient;
     private final long refreshSasBeforeExpiry;
 
     //key= container name, value = sastoken
     private static Cache<String, String> tokenCache;
 
-    public BulkScanSasTokenCache(
+    public SasTokenCache(
         BulkScanProcessorClient bulkScanSasTokenClient,
         @Value("${bulk-scan-cache.refresh-before-expire-in-sec}") long refreshSasBeforeExpiry
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
@@ -40,7 +40,7 @@ public class SasTokenCache {
         this.bulkScanSasTokenClient = bulkScanSasTokenClient;
         this.refreshSasBeforeExpiry = refreshSasBeforeExpiry;
         tokenCache = Caffeine.newBuilder()
-            .expireAfter(new BulkScanSasTokenCacheExpiry())
+            .expireAfter(new SasTokenCacheExpiry())
             .build();
     }
 
@@ -72,7 +72,7 @@ public class SasTokenCache {
         return sasToken;
     }
 
-    private class BulkScanSasTokenCacheExpiry implements Expiry<String, String> {
+    private class SasTokenCacheExpiry implements Expiry<String, String> {
 
         public static final String MESSAGE = "Invalid SAS, the SAS expiration time parameter not found.";
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCache.java
@@ -35,7 +35,7 @@ public class SasTokenCache {
 
     public SasTokenCache(
         BulkScanProcessorClient bulkScanSasTokenClient,
-        @Value("${bulk-scan-cache.refresh-before-expire-in-sec}") long refreshSasBeforeExpiry
+        @Value("${sas-token-cache.refresh-before-expire-in-sec}") long refreshSasBeforeExpiry
     ) {
         this.bulkScanSasTokenClient = bulkScanSasTokenClient;
         this.refreshSasBeforeExpiry = refreshSasBeforeExpiry;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -101,7 +101,7 @@ flyway:
 storage-blob-processing-delay-in-minutes: ${STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES}
 public_key_der_file: ${STORAGE_BLOB_PUBLIC_KEY} # public key file in der format
 
-bulk-scan-cache:
+sas-token-cache:
     refresh-before-expire-in-sec: 30
 
 scheduling:

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 public class BlobContainerClientProxyTest {
 
     @Mock BlobContainerClient crimeClient;
-    @Mock BulkScanSasTokenCache bulkScanSasTokenCache;
+    @Mock SasTokenCache sasTokenCache;
     @Mock BlobContainerClientBuilder blobContainerClientBuilder;
     @Mock BlobContainerClientBuilderProvider blobContainerClientBuilderProvider;
 
@@ -53,7 +53,7 @@ public class BlobContainerClientProxyTest {
         this.blobContainerClientProxy = new BlobContainerClientProxy(
             crimeClient,
             blobContainerClientBuilderProvider,
-            bulkScanSasTokenCache
+            sasTokenCache
         );
     }
 
@@ -87,13 +87,13 @@ public class BlobContainerClientProxyTest {
 
         assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
 
-        verify(bulkScanSasTokenCache, never()).getSasToken(containerName);
+        verify(sasTokenCache, never()).getSasToken(containerName);
     }
 
     @Test
     void should_upload_to_bulk_scan_storage_when_target_storage_bulk_scan() {
 
-        given(bulkScanSasTokenCache.getSasToken(any())).willReturn("token1");
+        given(sasTokenCache.getSasToken(any())).willReturn("token1");
 
         given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
             .willReturn(blobContainerClientBuilder);
@@ -112,7 +112,7 @@ public class BlobContainerClientProxyTest {
             TargetStorageAccount.BULKSCAN
         );
 
-        verify(bulkScanSasTokenCache).getSasToken(containerName);
+        verify(sasTokenCache).getSasToken(containerName);
 
         // then
         ArgumentCaptor<ByteArrayInputStream> data = ArgumentCaptor.forClass(ByteArrayInputStream.class);
@@ -132,7 +132,7 @@ public class BlobContainerClientProxyTest {
 
         assertThat(data.getValue().readAllBytes()).isEqualTo(blobContent);
 
-        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+        verify(sasTokenCache, never()).removeFromCache(containerName);
 
     }
 
@@ -156,7 +156,7 @@ public class BlobContainerClientProxyTest {
             )
         ).isInstanceOf(BlobStorageException.class);
 
-        verify(bulkScanSasTokenCache).removeFromCache(containerName);
+        verify(sasTokenCache).removeFromCache(containerName);
 
     }
 
@@ -176,7 +176,7 @@ public class BlobContainerClientProxyTest {
             )
         ).isInstanceOf(BlobStorageException.class);
 
-        verify(bulkScanSasTokenCache, never()).removeFromCache(containerName);
+        verify(sasTokenCache, never()).removeFromCache(containerName);
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
@@ -26,13 +26,13 @@ class SasTokenCacheTest {
     @Mock
     private BulkScanProcessorClient bulkScanProcessorClient;
 
-    private SasTokenCache bulkScanContainerClientCache;
+    private SasTokenCache sasTokenCache;
 
     private long refreshSasBeforeExpiry = 30;
 
     @BeforeEach
     private void setUp() {
-        this.bulkScanContainerClientCache = new SasTokenCache(
+        this.sasTokenCache = new SasTokenCache(
             bulkScanProcessorClient,
             refreshSasBeforeExpiry
         );
@@ -47,7 +47,7 @@ class SasTokenCacheTest {
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
         String sasToken =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
         assertThat(sasToken).isEqualTo(token);
         verify(bulkScanProcessorClient).getSasToken(containerName);
@@ -61,7 +61,7 @@ class SasTokenCacheTest {
 
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
-        assertThatThrownBy(() -> bulkScanContainerClientCache.getSasToken(containerName))
+        assertThatThrownBy(() -> sasTokenCache.getSasToken(containerName))
             .isInstanceOf(InvalidSasTokenException.class)
             .hasMessageContaining("Invalid SAS, the SAS expiration time parameter not found.");
     }
@@ -78,12 +78,12 @@ class SasTokenCacheTest {
         given(bulkScanProcessorClient.getSasToken(containerName)).willReturn(sasTokenResponse);
 
         String sasToken =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
         assertThat(sasToken).isNotNull();
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
         assertThat(sasToken).isSameAs(sasToken2);
         verify(bulkScanProcessorClient, times(1)).getSasToken(containerName);
@@ -108,10 +108,10 @@ class SasTokenCacheTest {
             .willReturn(sasTokenResponse1).willReturn(sasTokenResponse2);
 
         String sasToken1 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
         assertThat(sasToken1).isNotNull();
         assertThat(sasToken2).isNotNull();
 
@@ -134,12 +134,12 @@ class SasTokenCacheTest {
             .willReturn(new SasTokenResponse(token1), new SasTokenResponse(token2));
 
         String sasToken1 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
-        bulkScanContainerClientCache.removeFromCache(containerName);
+        sasTokenCache.removeFromCache(containerName);
 
         String sasToken2 =
-            bulkScanContainerClientCache.getSasToken(containerName);
+            sasTokenCache.getSasToken(containerName);
 
         assertThat(sasToken1).isEqualTo(token1);
         assertThat(sasToken2).isEqualTo(token2);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/SasTokenCacheTest.java
@@ -21,18 +21,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class BulkScanSasTokenCacheTest {
+class SasTokenCacheTest {
 
     @Mock
     private BulkScanProcessorClient bulkScanProcessorClient;
 
-    private BulkScanSasTokenCache bulkScanContainerClientCache;
+    private SasTokenCache bulkScanContainerClientCache;
 
     private long refreshSasBeforeExpiry = 30;
 
     @BeforeEach
     private void setUp() {
-        this.bulkScanContainerClientCache = new BulkScanSasTokenCache(
+        this.bulkScanContainerClientCache = new SasTokenCache(
             bulkScanProcessorClient,
             refreshSasBeforeExpiry
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1377


### Change description ###
Renamed `BulkScanSasTokenCache` as `SasTokenCache` which will be used for PCQ container in the next PR.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
