### PR TITLE
Use PCQ storage to dispatch the PCQ envelopes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProvider.java
@@ -10,18 +10,27 @@ public class BlobContainerClientBuilderProvider {
 
     final HttpClient httpClient;
     final String bulkScanStorageUrl;
+    final String pcqStorageUrl;
 
     public BlobContainerClientBuilderProvider(
         HttpClient httpClient,
-        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl
+        @Value("${storage.bulkscan.url}") String bulkScanStorageUrl,
+        @Value("${storage.pcq.url}") String pcqStorageUrl
     ) {
         this.httpClient = httpClient;
         this.bulkScanStorageUrl = bulkScanStorageUrl;
+        this.pcqStorageUrl = pcqStorageUrl;
     }
 
     public BlobContainerClientBuilder getBlobContainerClientBuilder() {
         return new BlobContainerClientBuilder()
             .httpClient(httpClient)
             .endpoint(bulkScanStorageUrl);
+    }
+
+    public BlobContainerClientBuilder getPcqBlobContainerClientBuilder() {
+        return new BlobContainerClientBuilder()
+            .httpClient(httpClient)
+            .endpoint(pcqStorageUrl);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
@@ -48,7 +48,7 @@ public class BlobContainerClientProxy {
                 return crimeClient;
             case PCQ:
                 return blobContainerClientBuilderProvider
-                    .getBlobContainerClientBuilder()
+                    .getPcqBlobContainerClientBuilder()
                     .sasToken(sasTokenCache.getPcqSasToken(containerName))
                     .containerName(containerName)
                     .buildClient();

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProviderTest.java
@@ -23,4 +23,13 @@ class BlobContainerClientBuilderProviderTest {
 
         assertThat(blobContainerClientBuilder).isNotNull();
     }
+
+    @Test
+    void should_provide_pcq_container_client_builder() {
+
+        BlobContainerClientBuilder blobContainerClientBuilder = blobContainerClientBuilderProvider
+            .getPcqBlobContainerClientBuilder();
+
+        assertThat(blobContainerClientBuilder).isNotNull();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientBuilderProviderTest.java
@@ -9,12 +9,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class BlobContainerClientBuilderProviderTest {
 
-
     @Mock
     private HttpClient httpClient;
 
     private BlobContainerClientBuilderProvider blobContainerClientBuilderProvider
-        = new BlobContainerClientBuilderProvider(httpClient, "http://example.com");
+        = new BlobContainerClientBuilderProvider(httpClient, "http://example.com", "http://testpcq.com");
 
     @Test
     void should_provide_builder() {

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
@@ -144,15 +144,22 @@ public class BlobContainerClientProxyTest {
         names = {"BULKSCAN", "PCQ"}
     )
     void should_invalidate_cache_when_upload_returns_error_response_40x(TargetStorageAccount storageAccount) {
-
+        // given
         HttpResponse mockHttpResponse = mock(HttpResponse.class);
         given(mockHttpResponse.getStatusCode()).willReturn(401);
 
-        given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
-            .willReturn(blobContainerClientBuilder);
+        if (storageAccount == TargetStorageAccount.PCQ) {
+            given(blobContainerClientBuilderProvider.getPcqBlobContainerClientBuilder())
+                .willReturn(blobContainerClientBuilder);
+        } else if (storageAccount == TargetStorageAccount.BULKSCAN) {
+            given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
+                .willReturn(blobContainerClientBuilder);
+        }
+
         given(blobContainerClientBuilder.sasToken(any())).willThrow(
             new BlobStorageException("Sas invalid 401", mockHttpResponse, null));
 
+        // then
         assertThatThrownBy(
             () -> blobContainerClientProxy.upload(
                 blobName,
@@ -191,7 +198,7 @@ public class BlobContainerClientProxyTest {
         // given
         given(sasTokenCache.getPcqSasToken(any())).willReturn("token1");
 
-        given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
+        given(blobContainerClientBuilderProvider.getPcqBlobContainerClientBuilder())
             .willReturn(blobContainerClientBuilder);
         given(blobContainerClientBuilder.containerName(containerName)).willReturn(blobContainerClientBuilder);
         given(blobContainerClientBuilder.sasToken("token1")).willReturn(blobContainerClientBuilder);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1377

### Change description ###
- Add PCQ storage URL to build the PCQ blob container client
- Use PCQ storage when dispatching the PCQ envelopes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
