### PR TITLE
Add dummy config for smoke tests

### DIFF
--- a/src/smokeTest/resources/application.conf
+++ b/src/smokeTest/resources/application.conf
@@ -14,4 +14,5 @@ test-not-yet-valid-key-store = ${TEST_NOT_YET_VALID_KEY_STORE}
 test-not-yet-valid-key-store-password = ${TEST_NOT_YET_VALID_KEY_STORE_PASSWORD}
 test-subscription-key = ${TEST_SUBSCRIPTION_KEY}
 
-test_reconciliation_api_key = ${TEST_RECONCILIATION_API_KEY}
+test_reconciliation_api_key = "dummy"
+test_reconciliation_api_key = ${?TEST_RECONCILIATION_API_KEY}


### PR DESCRIPTION
### Change description ###

Smoke tests are not working at the moment due to env var not found. This config is for disabled test suite so just adding dummy value

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
