### PR TITLE
change BULKSCAN TargetStorageAccount name

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,3 @@ You should get a response with status 200 and a token in the body.
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
-

--- a/README.md
+++ b/README.md
@@ -142,3 +142,4 @@ You should get a response with status 200 and a token in the body.
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -3,7 +3,7 @@ storage.account-key=testkey
 
 service.storage-config[0].source-container=bulkscan
 service.storage-config[0].sas-validity=300
-service.storage-config[0].target-storage-account=bulkscan
+service.storage-config[0].target-storage-account=cft
 service.storage-config[0].target-container=bulkscan-target
 
 flyway.skip-migrations=false

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/config/TargetStorageAccount.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/config/TargetStorageAccount.java
@@ -4,7 +4,7 @@ package uk.gov.hmcts.reform.blobrouter.config;
  * Represents destination storage account for blobs.
  */
 public enum TargetStorageAccount {
-    BULKSCAN,
+    CFT,
     CRIME,
     PCQ,
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/DetailedReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/DetailedReportService.java
@@ -46,7 +46,7 @@ public class DetailedReportService {
     public void process(LocalDate date, TargetStorageAccount account) {
 
         Assert.isTrue(
-            account == TargetStorageAccount.BULKSCAN,
+            account == TargetStorageAccount.CFT,
             "Only BULKSCAN account can be processed."
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTask.java
@@ -31,7 +31,7 @@ public class DetailedReportTask {
     public void run() {
         logger.info("Started {} job", TASK_NAME);
 
-        detailedReportService.process(LocalDate.now(), TargetStorageAccount.BULKSCAN);
+        detailedReportService.process(LocalDate.now(), TargetStorageAccount.CFT);
 
         logger.info("Finished {} job", TASK_NAME);
     }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxy.java
@@ -38,7 +38,7 @@ public class BlobContainerClientProxy {
 
     private BlobContainerClient get(TargetStorageAccount targetStorageAccount, String containerName) {
         switch (targetStorageAccount) {
-            case BULKSCAN:
+            case CFT:
                 return blobContainerClientBuilderProvider
                     .getBlobContainerClientBuilder()
                     .sasToken(sasTokenCache.getSasToken(containerName))
@@ -96,7 +96,7 @@ public class BlobContainerClientProxy {
                 (System.currentTimeMillis() - uploadStartTime),
                 ex.getResponse() == null ? ex.getMessage() : ex.getResponse().getStatusCode()
             );
-            if ((targetStorageAccount == TargetStorageAccount.BULKSCAN
+            if ((targetStorageAccount == TargetStorageAccount.CFT
                 || targetStorageAccount == TargetStorageAccount.PCQ)
                 && HttpStatus.valueOf(ex.getResponse().getStatusCode()).is4xxClientError()) {
                 sasTokenCache.removeFromCache(destinationContainer);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,15 +45,15 @@ service:
   storage-config:
     - source-container: bulkscan
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: bulkscan
     - source-container: bulkscanauto
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: bulkscanauto
     - source-container: cmc
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: cmc
     - source-container: crime
       sas-validity: 300 #In seconds
@@ -67,23 +67,23 @@ service:
       target-container: ${PCQ_DESTINATION_CONTAINER}
     - source-container: divorce
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: divorce
     - source-container: finrem
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: finrem
     - source-container: probate
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: probate
     - source-container: sscs
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: sscs
     - source-container: publiclaw
       sas-validity: 300 #In seconds
-      target-storage-account: bulkscan
+      target-storage-account: cft
       target-container: publiclaw
 
 queue:

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/report/ReconciliationMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/report/ReconciliationMapperTest.java
@@ -21,7 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.PCQ;
 
@@ -95,7 +95,7 @@ class ReconciliationMapperTest {
         ReconciliationStatement reconciliationStatement =
             reconciliationMapper.convertToReconciliationStatement(
                 envelopeSupplierStatement,
-                BULKSCAN
+                CFT
             );
 
         // then
@@ -153,11 +153,11 @@ class ReconciliationMapperTest {
     }
 
     private void setupStorageConfig() {
-        given(storageConfig.get("sscs")).willReturn(createStorageConfigItem(BULKSCAN));
-        given(storageConfig.get("probate")).willReturn(createStorageConfigItem(BULKSCAN));
+        given(storageConfig.get("sscs")).willReturn(createStorageConfigItem(CFT));
+        given(storageConfig.get("probate")).willReturn(createStorageConfigItem(CFT));
         given(storageConfig.get("crime")).willReturn(createStorageConfigItem(CRIME));
         given(storageConfig.get("pcq")).willReturn(createStorageConfigItem(PCQ));
-        given(storageConfig.get("cmc")).willReturn(createStorageConfigItem(BULKSCAN));
+        given(storageConfig.get("cmc")).willReturn(createStorageConfigItem(CFT));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/DetailedReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/DetailedReportServiceTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,14 +77,14 @@ class DetailedReportServiceTest {
     void should_not_process_further_if_there_is_no_summary_report() {
         //given
         LocalDate date = LocalDate.now();
-        given(reconciliationReportRepository.getLatestReconciliationReport(date, BULKSCAN.name()))
+        given(reconciliationReportRepository.getLatestReconciliationReport(date, CFT.name()))
             .willReturn(Optional.empty());
 
         //when
-        service.process(date, BULKSCAN);
+        service.process(date, CFT);
 
         // then
-        verify(reconciliationReportRepository).getLatestReconciliationReport(date, BULKSCAN.name());
+        verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
         verifyNoMoreInteractions(reconciliationReportRepository);
         verifyNoInteractions(reconciliationService);
         verifyNoInteractions(reconciliationMapper);
@@ -96,14 +96,14 @@ class DetailedReportServiceTest {
     void should_not_process_further_if_detailed_report_already_present() {
         //given
         LocalDate date = LocalDate.now();
-        given(reconciliationReportRepository.getLatestReconciliationReport(date, BULKSCAN.name()))
+        given(reconciliationReportRepository.getLatestReconciliationReport(date, CFT.name()))
             .willReturn(Optional.of(createReconciliationReport("{}", "{\"report\" :1}")));
 
         //when
-        service.process(date, BULKSCAN);
+        service.process(date, CFT);
 
         // then
-        verify(reconciliationReportRepository).getLatestReconciliationReport(date, BULKSCAN.name());
+        verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
         verifyNoMoreInteractions(reconciliationReportRepository);
         verifyNoInteractions(reconciliationService);
         verifyNoInteractions(reconciliationMapper);
@@ -115,12 +115,12 @@ class DetailedReportServiceTest {
     void should_not_process_further_if_no_supplier_statement() {
         //given
         LocalDate date = LocalDate.now();
-        given(reconciliationReportRepository.getLatestReconciliationReport(date, BULKSCAN.name()))
+        given(reconciliationReportRepository.getLatestReconciliationReport(date, CFT.name()))
             .willReturn(Optional.of(createReconciliationReport("{\"a\" :1}", null)));
         given(reconciliationService.getSupplierStatement(date)).willReturn(Optional.empty());
 
         //when
-        service.process(date, BULKSCAN);
+        service.process(date, CFT);
 
         // then
         verify(reconciliationService).getSupplierStatement(date);
@@ -128,7 +128,7 @@ class DetailedReportServiceTest {
         verifyNoInteractions(reconciliationMapper);
         verifyNoInteractions(bulkScanProcessorClient);
         verifyNoInteractions(objectMapper);
-        verify(reconciliationReportRepository).getLatestReconciliationReport(date, BULKSCAN.name());
+        verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
         verifyNoMoreInteractions(reconciliationReportRepository);
     }
 
@@ -137,7 +137,7 @@ class DetailedReportServiceTest {
         //given
         LocalDate date = LocalDate.now();
         var reconciliationReport = createReconciliationReport("{\"a\" :1}", null);
-        given(reconciliationReportRepository.getLatestReconciliationReport(date, BULKSCAN.name()))
+        given(reconciliationReportRepository.getLatestReconciliationReport(date, CFT.name()))
             .willReturn(Optional.of(reconciliationReport));
 
         String content = Resources.toString(
@@ -170,18 +170,18 @@ class DetailedReportServiceTest {
             .willReturn(contentJson);
 
         //when
-        service.process(date, BULKSCAN);
+        service.process(date, CFT);
 
         // then
         verify(reconciliationService).getSupplierStatement(date);
         verifyNoMoreInteractions(reconciliationService);
-        verify(reconciliationMapper).convertToReconciliationStatement(any(), eq(BULKSCAN));
+        verify(reconciliationMapper).convertToReconciliationStatement(any(), eq(CFT));
         verifyNoMoreInteractions(reconciliationMapper);
         verify(bulkScanProcessorClient).postReconciliationReport(reconciliationStatement);
         verifyNoMoreInteractions(bulkScanProcessorClient);
         verify(objectMapper).writeValueAsString(reconciliationReportResponse);
         verifyNoMoreInteractions(objectMapper);
-        verify(reconciliationReportRepository).getLatestReconciliationReport(date, BULKSCAN.name());
+        verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
         verify(reconciliationReportRepository)
             .updateDetailedContent(reconciliationReport.id, contentJson);
         verifyNoMoreInteractions(reconciliationReportRepository);
@@ -194,7 +194,7 @@ class DetailedReportServiceTest {
         return new ReconciliationReport(
             UUID.randomUUID(),
             UUID.randomUUID(),
-            BULKSCAN.name(),
+            CFT.name(),
             summaryContent,
             detailedContent,
             "1.0",

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/SummaryReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/SummaryReportServiceTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.PCQ;
 
@@ -117,7 +117,7 @@ class SummaryReportServiceTest {
         given(option.get()).willReturn(envelopeSupplierStatement);
 
         var existingReportList = List.of(
-            getReconciliationReport(envelopeSupplierStatement.id, BULKSCAN.name()),
+            getReconciliationReport(envelopeSupplierStatement.id, CFT.name()),
             getReconciliationReport(envelopeSupplierStatement.id, CRIME.name()),
             getReconciliationReport(envelopeSupplierStatement.id, PCQ.name())
         );
@@ -171,7 +171,7 @@ class SummaryReportServiceTest {
     void should_continue_processing_with_next_target_storage_if_one_fails()
         throws Exception {
         // given
-        given(storageConfig.get(anyString())).willReturn(createStorageConfigItem(BULKSCAN));
+        given(storageConfig.get(anyString())).willReturn(createStorageConfigItem(CFT));
         LocalDate date = LocalDate.now();
         String content = Resources.toString(
             getResource("reconciliation/valid-supplier-statement.json"),
@@ -395,9 +395,9 @@ class SummaryReportServiceTest {
     }
 
     private void setupStorageConfig() {
-        given(storageConfig.get("sscs")).willReturn(createStorageConfigItem(BULKSCAN));
-        given(storageConfig.get("probate")).willReturn(createStorageConfigItem(BULKSCAN));
-        given(storageConfig.get("cmc")).willReturn(createStorageConfigItem(BULKSCAN));
+        given(storageConfig.get("sscs")).willReturn(createStorageConfigItem(CFT));
+        given(storageConfig.get("probate")).willReturn(createStorageConfigItem(CFT));
+        given(storageConfig.get("cmc")).willReturn(createStorageConfigItem(CFT));
         given(storageConfig.get("crime")).willReturn(createStorageConfigItem(CRIME));
         given(storageConfig.get("pcq")).willReturn(createStorageConfigItem(PCQ));
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTaskTest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 
 class DetailedReportTaskTest {
 
@@ -23,7 +23,7 @@ class DetailedReportTaskTest {
         task.run();
 
         // then
-        verify(detailedReportService, times(1)).process(LocalDate.now(), BULKSCAN);
+        verify(detailedReportService, times(1)).process(LocalDate.now(), CFT);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/BlobContentExtractorTest.java
@@ -79,7 +79,7 @@ class BlobContentExtractorTest {
         var content = "irrelevant".getBytes();
 
         // when
-        var result = extractor.getContentToUpload(content, TargetStorageAccount.BULKSCAN);
+        var result = extractor.getContentToUpload(content, TargetStorageAccount.CFT);
 
         // then
         assertThat(result).isEqualTo(content);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobContainerClientProxyTest.java
@@ -111,7 +111,7 @@ public class BlobContainerClientProxyTest {
             blobName,
             blobContent,
             containerName,
-            TargetStorageAccount.BULKSCAN
+            TargetStorageAccount.CFT
         );
 
         verify(sasTokenCache).getSasToken(containerName);
@@ -141,7 +141,7 @@ public class BlobContainerClientProxyTest {
     @ParameterizedTest
     @EnumSource(
         value = TargetStorageAccount.class,
-        names = {"BULKSCAN", "PCQ"}
+        names = {"CFT", "PCQ"}
     )
     void should_invalidate_cache_when_upload_returns_error_response_40x(TargetStorageAccount storageAccount) {
         // given
@@ -151,7 +151,7 @@ public class BlobContainerClientProxyTest {
         if (storageAccount == TargetStorageAccount.PCQ) {
             given(blobContainerClientBuilderProvider.getPcqBlobContainerClientBuilder())
                 .willReturn(blobContainerClientBuilder);
-        } else if (storageAccount == TargetStorageAccount.BULKSCAN) {
+        } else if (storageAccount == TargetStorageAccount.CFT) {
             given(blobContainerClientBuilderProvider.getBlobContainerClientBuilder())
                 .willReturn(blobContainerClientBuilder);
         }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/storage/BlobDispatcherTest.java
@@ -16,7 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 
 @ExtendWith(MockitoExtension.class)
 class BlobDispatcherTest {
@@ -40,14 +40,14 @@ class BlobDispatcherTest {
         final byte[] blobContent = "some data".getBytes();
         final String container = "container";
 
-        doNothing().when(blobContainerClientProxy).upload(blobName, blobContent, container, BULKSCAN);
+        doNothing().when(blobContainerClientProxy).upload(blobName, blobContent, container, CFT);
 
         // when
-        dispatcher.dispatch(blobName, blobContent, container, BULKSCAN);
+        dispatcher.dispatch(blobName, blobContent, container, CFT);
 
         // then
         verify(blobContainerClientProxy)
-            .upload(blobName, blobContent, container, BULKSCAN);
+            .upload(blobName, blobContent, container, CFT);
 
     }
 
@@ -60,7 +60,7 @@ class BlobDispatcherTest {
 
         // when
         Throwable exc = catchThrowable(
-            () -> dispatcher.dispatch("foo.zip", "data".getBytes(), "some_container", BULKSCAN)
+            () -> dispatcher.dispatch("foo.zip", "data".getBytes(), "some_container", CFT)
         );
 
         // then

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorContinuationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorContinuationTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
 import static uk.gov.hmcts.reform.blobrouter.services.BlobVerifier.VerificationResult.error;
 import static uk.gov.hmcts.reform.blobrouter.services.BlobVerifier.VerificationResult.ok;
@@ -50,7 +50,7 @@ public class BlobProcessorContinuationTest {
     void setUp() {
         given(serviceConfiguration.getStorageConfig())
             .willReturn(Map.of(
-                "s1", cfg("s1", "t1", BULKSCAN),
+                "s1", cfg("s1", "t1", CFT),
                 "s2", cfg("s2", "t2", CRIME)
             ));
         blobProcessor = new BlobProcessor(
@@ -80,7 +80,7 @@ public class BlobProcessorContinuationTest {
         // then
         verify(envelopeService, never()).createNewEnvelope(any(), any(), any());
         verify(envelopeService).markAsDispatched(id);
-        verify(blobDispatcher).dispatch(fileName, content, "t1", BULKSCAN);
+        verify(blobDispatcher).dispatch(fileName, content, "t1", CFT);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/tasks/processors/BlobProcessorTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.http.HttpStatus.BAD_GATEWAY;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.BULKSCAN;
+import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 import static uk.gov.hmcts.reform.blobrouter.services.BlobVerifier.VerificationResult.error;
 import static uk.gov.hmcts.reform.blobrouter.services.BlobVerifier.VerificationResult.ok;
 
@@ -44,7 +44,7 @@ class BlobProcessorTest {
 
     private static final String SOURCE_CONTAINER = "sourceContainer1";
     private static final String TARGET_CONTAINER = "targetContainer1";
-    private static final TargetStorageAccount TARGET_STORAGE_ACCOUNT = BULKSCAN;
+    private static final TargetStorageAccount TARGET_STORAGE_ACCOUNT = CFT;
 
     @Mock(lenient = true) BlobClient blobClient;
     @Mock(lenient = true) BlobProperties blobProperties;
@@ -60,7 +60,7 @@ class BlobProcessorTest {
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
         blobExists("envelope1.zip", SOURCE_CONTAINER);
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
         given(verifier.verifyZip(any(), any())).willReturn(ok());
 
         willThrow(new RuntimeException("Exception message"))
@@ -89,7 +89,7 @@ class BlobProcessorTest {
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
         blobExists("envelope1.zip", SOURCE_CONTAINER);
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
         given(verifier.verifyZip(any(), any())).willReturn(ok());
 
         willThrow(new RuntimeException(
@@ -125,7 +125,7 @@ class BlobProcessorTest {
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
         blobExists("envelope1.zip", SOURCE_CONTAINER);
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
 
         HttpResponse errorResponse = mock(HttpResponse.class);
         given(errorResponse.getStatusCode()).willReturn(BAD_GATEWAY.value());
@@ -155,7 +155,7 @@ class BlobProcessorTest {
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
         blobExists("envelope1.zip", SOURCE_CONTAINER);
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
 
         willThrow(new RuntimeException("test")).given(blobClient).download(any());
 
@@ -179,7 +179,7 @@ class BlobProcessorTest {
         // given
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
 
         OffsetDateTime blobCreationTime = OffsetDateTime.now();
         String fileName = "envelope1.zip";
@@ -202,7 +202,7 @@ class BlobProcessorTest {
         var id = UUID.randomUUID();
         given(envelopeService.createNewEnvelope(any(), any(), any())).willReturn(id);
 
-        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, BULKSCAN);
+        setupContainerConfig(SOURCE_CONTAINER, TARGET_CONTAINER, CFT);
 
         OffsetDateTime blobCreationTime = OffsetDateTime.now();
         String fileName = "envelope1.zip";
@@ -227,7 +227,7 @@ class BlobProcessorTest {
         var targetContainerName = "targetContainer1";
         var content = "some zip file content".getBytes();
 
-        setupContainerConfig(sourceContainerName, targetContainerName, BULKSCAN);
+        setupContainerConfig(sourceContainerName, targetContainerName, CFT);
         blobExists(fileName, sourceContainerName);
         given(blobContentExtractor.getContentToUpload(any(), any())).willReturn(content);
 
@@ -243,7 +243,7 @@ class BlobProcessorTest {
         // then
         verifyNewEnvelopeHasBeenCreated();
         verify(blobDispatcher, times(1))
-            .dispatch(eq(fileName), aryEq(content), eq(targetContainerName), eq(BULKSCAN));
+            .dispatch(eq(fileName), aryEq(content), eq(targetContainerName), eq(CFT));
         verify(envelopeService).markAsDispatched(id);
     }
 


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

change TargetStorageAccount name.
We will start using target storage name in the DB with reconciliation. 
I think CFT is better than BULKSCAN


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
