### PR TITLE
Readiness config

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest
-public class ReadinessTest {
+class ReadinessTest {
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
@@ -18,7 +18,7 @@ public class ReadinessTest {
     private MockMvc mockMvc;
 
     @Test
-    void should_contain_readinessState() throws Exception {
+    void should_readiness_contain_db_status() throws Exception {
         mockMvc
             .perform(
                 get("/health/readiness")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.blobrouter.health;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class ReadinessTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void should_contain_readinessState() throws Exception {
+        mockMvc
+            .perform(
+                get("/health/readiness")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"))
+            .andExpect(jsonPath("$.components.db.status").value("UP"))
+        ;
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/health/ReadinessTest.java
@@ -18,7 +18,7 @@ class ReadinessTest {
     private MockMvc mockMvc;
 
     @Test
-    void should_readiness_contain_db_status() throws Exception {
+    void readiness_should_contain_db_status() throws Exception {
         mockMvc
             .perform(
                 get("/health/readiness")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ management:
       show-details: "always"
       group:
         readiness:
-          include: readinessState, db
+          include: db
   endpoints:
     web:
       base-path: /

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ management:
   endpoint:
     health:
       show-details: "always"
+      group:
+        readiness:
+          include: readinessState, db
   endpoints:
     web:
       base-path: /

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ management:
       show-details: "always"
       group:
         readiness:
-          include: db
+          include: readinessState, db
   endpoints:
     web:
       base-path: /


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1347


The result of accessing `/health/readiness` endpoint looks like this:

`{ "status": "UP", "components": { "db": { "status": "UP", "details": { "database": "PostgreSQL", "validationQuery": "isValid()" } }, "readinessState": { "status": "UP" } } }`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
