### PR TITLE
Refactor Reconciliation Mail Service to generate and email reports manually

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/ReconciliationMailTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/ReconciliationMailTask.java
@@ -38,7 +38,7 @@ public class ReconciliationMailTask {
     public void run() {
         logger.info("Started {} job", TASK_NAME);
 
-        reconciliationMailService.process(LocalDate.now(UTC), AVAILABLE_ACCOUNTS);
+        reconciliationMailService.process(LocalDate.now(UTC), AVAILABLE_ACCOUNTS, true);
 
         logger.info("Finished {} job", TASK_NAME);
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/ReconciliationMailTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/ReconciliationMailTaskTest.java
@@ -26,6 +26,6 @@ class ReconciliationMailTaskTest {
 
         // then
         verify(reconciliationMailService, times(1))
-            .process(LocalDate.now(UTC), List.of(CFT, CRIME));;
+            .process(LocalDate.now(UTC), List.of(CFT, CRIME), true);;
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1399

### Change description ###
Add `automatedEmail` boolean flag to ReconcilitionMailService methods to skip the report already sent condition.
When manually triggered to generate and send reports and the automated email was sent already, it should generate and email the reports again.
This will be used in the next PR.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
