### PR TITLE
Endpoint to generate and email Reconciliation reports

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/IntegrationTestConfig.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/config/IntegrationTestConfig.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.blobrouter.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.ReconciliationMailService;
+
+import static org.mockito.Mockito.mock;
+
+@Configuration
+public class IntegrationTestConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "scheduling.task.send-reconciliation-report-mail.enabled", havingValue = "false")
+    public ReconciliationMailService reconciliationMailService() {
+        return mock(ReconciliationMailService.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportController.java
@@ -6,10 +6,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.model.out.SearchResult;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.DetailedReportService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.ReconciliationMailService;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.service.ReconciliationService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.SummaryReportService;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
@@ -18,9 +24,20 @@ import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 public class ReconciliationReportController {
 
     private final ReconciliationService service;
+    private final ReconciliationMailService reconciliationMailService;
+    private final DetailedReportService detailedReportService;
+    private final SummaryReportService summaryReportService;
 
-    public ReconciliationReportController(ReconciliationService service) {
+    public ReconciliationReportController(
+        ReconciliationService service,
+        SummaryReportService summaryReportService,
+        DetailedReportService detailedReportService,
+        ReconciliationMailService reconciliationMailService
+    ) {
         this.service = service;
+        this.summaryReportService = summaryReportService;
+        this.detailedReportService = detailedReportService;
+        this.reconciliationMailService = reconciliationMailService;
     }
 
     @GetMapping
@@ -28,5 +45,21 @@ public class ReconciliationReportController {
         @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date
     ) {
         return new SearchResult(service.getReconciliationReports(date));
+    }
+
+    @GetMapping(path = "/generate-and-email-report")
+    public void generateAndEmailReconciliationReports(
+        @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date
+    ) {
+        List<TargetStorageAccount> availableAccounts = Arrays.asList(
+            TargetStorageAccount.CFT, TargetStorageAccount.CRIME
+        );
+
+        // generate reports
+        summaryReportService.process(date);
+        detailedReportService.process(date, TargetStorageAccount.CFT);
+
+        // email report
+        reconciliationMailService.process(date, availableAccounts);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1399

### Change description ###
Added endpoint with the path `reconciliation-reports/generate-and-email-report` 
- Generates reconciliation reports both summary and detailed summary reports.
- Sends email when new reports are generated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
