### PR TITLE
Refactor Reconciliation detailed report service

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationReportGenerationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationReportGenerationControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.controller.ReconciliationReportGenerationController;
-import uk.gov.hmcts.reform.blobrouter.reconciliation.service.DetailedReportService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.CftDetailedReportService;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.service.ReconciliationMailService;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.service.SummaryReportService;
 
@@ -33,7 +33,7 @@ public class ReconciliationReportGenerationControllerTest {
     private SummaryReportService summaryReportService;
 
     @MockBean
-    private DetailedReportService detailedReportService;
+    private CftDetailedReportService detailedReportService;
 
     @MockBean
     private ReconciliationMailService mailService;
@@ -64,7 +64,7 @@ public class ReconciliationReportGenerationControllerTest {
             .andExpect(status().isOk());
 
         verify(summaryReportService).process(date);
-        verify(detailedReportService).process(date, TargetStorageAccount.CFT);
+        verify(detailedReportService).process(date);
         verify(mailService).process(date, Arrays.asList(TargetStorageAccount.values()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
-import uk.gov.hmcts.reform.blobrouter.reconciliation.service.DetailedReportService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.CftDetailedReportService;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.service.ReconciliationMailService;
 import uk.gov.hmcts.reform.blobrouter.reconciliation.service.SummaryReportService;
 
@@ -20,16 +20,16 @@ import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 public class ReconciliationReportGenerationController {
 
     private final ReconciliationMailService reconciliationMailService;
-    private final DetailedReportService detailedReportService;
+    private final CftDetailedReportService cftDetailedReportService;
     private final SummaryReportService summaryReportService;
 
     public ReconciliationReportGenerationController(
         ReconciliationMailService reconciliationMailService,
-        DetailedReportService detailedReportService,
+        CftDetailedReportService cftDetailedReportService,
         SummaryReportService summaryReportService
     ) {
         this.reconciliationMailService = reconciliationMailService;
-        this.detailedReportService = detailedReportService;
+        this.cftDetailedReportService = cftDetailedReportService;
         this.summaryReportService = summaryReportService;
     }
 
@@ -39,7 +39,7 @@ public class ReconciliationReportGenerationController {
     ) {
         // generate reports
         summaryReportService.process(date);
-        detailedReportService.process(date, TargetStorageAccount.CFT);
+        cftDetailedReportService.process(date);
 
         // email report
         reconciliationMailService.process(date, Arrays.asList(TargetStorageAccount.values()));

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTask.java
@@ -5,8 +5,7 @@ import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;
-import uk.gov.hmcts.reform.blobrouter.reconciliation.service.DetailedReportService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.CftDetailedReportService;
 
 import java.time.LocalDate;
 
@@ -20,10 +19,10 @@ public class DetailedReportTask {
     private static final String TASK_NAME = "create-reconciliation-detailed-report";
     private static final Logger logger = getLogger(DetailedReportTask.class);
 
-    private final DetailedReportService detailedReportService;
+    private final CftDetailedReportService cftDetailedReportService;
 
-    public DetailedReportTask(DetailedReportService detailedReportService) {
-        this.detailedReportService = detailedReportService;
+    public DetailedReportTask(CftDetailedReportService cftDetailedReportService) {
+        this.cftDetailedReportService = cftDetailedReportService;
     }
 
     @Scheduled(cron = "${scheduling.task.create-reconciliation-detailed-report.cron}", zone = EUROPE_LONDON)
@@ -31,7 +30,7 @@ public class DetailedReportTask {
     public void run() {
         logger.info("Started {} job", TASK_NAME);
 
-        detailedReportService.process(LocalDate.now(), TargetStorageAccount.CFT);
+        cftDetailedReportService.process(LocalDate.now());
 
         logger.info("Finished {} job", TASK_NAME);
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/CftDetailedReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/service/CftDetailedReportServiceTest.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -33,10 +32,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CRIME;
 
 @ExtendWith(MockitoExtension.class)
-class DetailedReportServiceTest {
+class CftDetailedReportServiceTest {
 
     @Mock private ReconciliationMapper reconciliationMapper;
     @Mock private ReconciliationService reconciliationService;
@@ -44,33 +42,17 @@ class DetailedReportServiceTest {
     @Mock private ObjectMapper objectMapper;
     @Mock private ReconciliationReportRepository reconciliationReportRepository;
 
-    private DetailedReportService service;
+    private CftDetailedReportService service;
 
     @BeforeEach
     void setUp() {
-        service = new DetailedReportService(
+        service = new CftDetailedReportService(
             reconciliationMapper,
             reconciliationReportRepository,
             reconciliationService,
             bulkScanProcessorClient,
             objectMapper
         );
-    }
-
-    @Test
-    void should_throw_exception_if_target_account_different_than_bulkscan() {
-        //given
-        LocalDate date = LocalDate.now();
-
-        //when
-        assertThrows(IllegalArgumentException.class, () -> service.process(date, CRIME));
-
-        // then
-        verifyNoInteractions(reconciliationReportRepository);
-        verifyNoInteractions(reconciliationService);
-        verifyNoInteractions(reconciliationMapper);
-        verifyNoInteractions(bulkScanProcessorClient);
-        verifyNoInteractions(objectMapper);
     }
 
     @Test
@@ -81,7 +63,7 @@ class DetailedReportServiceTest {
             .willReturn(Optional.empty());
 
         //when
-        service.process(date, CFT);
+        service.process(date);
 
         // then
         verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
@@ -100,7 +82,7 @@ class DetailedReportServiceTest {
             .willReturn(Optional.of(createReconciliationReport("{}", "{\"report\" :1}")));
 
         //when
-        service.process(date, CFT);
+        service.process(date);
 
         // then
         verify(reconciliationReportRepository).getLatestReconciliationReport(date, CFT.name());
@@ -120,7 +102,7 @@ class DetailedReportServiceTest {
         given(reconciliationService.getSupplierStatement(date)).willReturn(Optional.empty());
 
         //when
-        service.process(date, CFT);
+        service.process(date);
 
         // then
         verify(reconciliationService).getSupplierStatement(date);
@@ -170,7 +152,7 @@ class DetailedReportServiceTest {
             .willReturn(contentJson);
 
         //when
-        service.process(date, CFT);
+        service.process(date);
 
         // then
         verify(reconciliationService).getSupplierStatement(date);

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/reconciliation/task/DetailedReportTaskTest.java
@@ -1,29 +1,28 @@
 package uk.gov.hmcts.reform.blobrouter.reconciliation.task;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.blobrouter.reconciliation.service.DetailedReportService;
+import uk.gov.hmcts.reform.blobrouter.reconciliation.service.CftDetailedReportService;
 
 import java.time.LocalDate;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount.CFT;
 
 class DetailedReportTaskTest {
 
     @Test
     void should_call_summary_report_service() {
         // given
-        var detailedReportService = mock(DetailedReportService.class);
+        var cftDetailedReportService = mock(CftDetailedReportService.class);
 
-        var task = new DetailedReportTask(detailedReportService);
+        var task = new DetailedReportTask(cftDetailedReportService);
 
         // when
         task.run();
 
         // then
-        verify(detailedReportService, times(1)).process(LocalDate.now(), CFT);
+        verify(cftDetailedReportService, times(1)).process(LocalDate.now());
     }
 
 }


### PR DESCRIPTION
### Change description ###
Detailed report service generates only for the CFT storage account. 
so, renamed the service class and removed the method parameter for TargetStorageAccount.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
