### PR TITLE
Change manual reconciliation report generation endpoint path

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationReportGenerationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/ReconciliationReportGenerationControllerTest.java
@@ -41,7 +41,7 @@ public class ReconciliationReportGenerationControllerTest {
     @Test
     public void should_return_400_when_the_given_date_is_invalid() throws Exception {
         mockMvc.perform(
-            post("/reconciliation-reports/generate-and-email-report")
+            post("/reconciliation/generate-and-email-reports")
                 .queryParam("date", "20200911") // invalid date
         )
             .andDo(print())
@@ -57,7 +57,7 @@ public class ReconciliationReportGenerationControllerTest {
         // then
         mockMvc
             .perform(
-                post("/reconciliation-reports/generate-and-email-report")
+                post("/reconciliation/generate-and-email-reports")
                     .queryParam("date", date.format(DateTimeFormatter.ISO_DATE))
             )
             .andDo(print())

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.blobrouter.reconciliation.controller;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.blobrouter.config.TargetStorageAccount;

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/reconciliation/controller/ReconciliationReportGenerationController.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
 @RestController
-@RequestMapping(path = "/reconciliation-reports")
 public class ReconciliationReportGenerationController {
 
     private final ReconciliationMailService reconciliationMailService;
@@ -33,7 +32,7 @@ public class ReconciliationReportGenerationController {
         this.summaryReportService = summaryReportService;
     }
 
-    @PostMapping(path = "/generate-and-email-report")
+    @PostMapping(path = "/reconciliation/generate-and-email-reports")
     public void generateAndEmailReports(
         @RequestParam(name = "date") @DateTimeFormat(iso = DATE) LocalDate date
     ) {

--- a/src/smokeTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationApiTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationApiTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,6 +27,7 @@ public class ReconciliationApiTest extends ApiGatewayBaseTest {
     }
 
     @Test
+    @Disabled
     void should_accept_request_with_valid_certificate_and_valid_subscription_key() throws Exception {
         Response response = callReconciliationEndpoint(validClientKeyStore, validSubscriptionKey);
 

--- a/src/smokeTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationApiTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/blobrouter/ReconciliationApiTest.java
@@ -4,7 +4,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -27,7 +26,6 @@ public class ReconciliationApiTest extends ApiGatewayBaseTest {
     }
 
     @Test
-    @Disabled
     void should_accept_request_with_valid_certificate_and_valid_subscription_key() throws Exception {
         Response response = callReconciliationEndpoint(validClientKeyStore, validSubscriptionKey);
 


### PR DESCRIPTION
### Change description ###
The smoke tests for reconciliation endpoint are failing because the manual report generation endpoint path also matches with the condition below:
```<when condition="@(context.Request.Url.Path.Contains(&quot;reconciliation-report&quot;))">```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
