### PR TITLE
add report date to report table

### DIFF
--- a/src/main/resources/db/migration/V017__add_new_column_reconciliation_report.sql
+++ b/src/main/resources/db/migration/V017__add_new_column_reconciliation_report.sql
@@ -1,0 +1,2 @@
+ALTER TABLE envelope_reconciliation_reports
+ADD COLUMN report_for DATE DEFAULT NOW();


### PR DESCRIPTION

### Change description ###

add report date to report table.
currently we use create_at which is not clear. 
Report date and creation might be different.  Now there is 'default' it will be 'not null' in second version with code changes.
name suggestions welcomed. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
