### PR TITLE
fix: bump testcontainers to fix 2.4.0 docker issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,10 +246,10 @@ dependencies {
     exclude group: 'com.github.tomakehurst', module: 'wiremock-jre8-standalone'
   }
   integrationTestImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.1'
-  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.14.3', {
+  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.15.0-rc2', {
     exclude group: 'junit', module: 'junit'
   }
-  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.14.3'
+  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.15.0-rc2'
   integrationTestImplementation group: 'com.icegreen', name: 'greenmail', version: '1.5.13'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.blobrouter.controllers;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -214,7 +213,6 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(status().isBadRequest());
     }
 
-    @NotNull
     private Envelope envelope(String fileName, String container, Instant createdDate) {
         return new Envelope(
             UUID.randomUUID(),
@@ -229,12 +227,6 @@ public class EnvelopeControllerTest extends ControllerTestBase {
         );
     }
 
-    @NotNull
-    private Envelope envelope(String fileName, String container) {
-        return envelope(fileName, container, now());
-    }
-
-    @NotNull
     private EnvelopeEvent envelopeEvent(UUID envelopeId, int eventId, EventType eventType) {
         return new EnvelopeEvent(eventId, envelopeId, eventType, null, null, now());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/data/EnvelopeEventRepositoryTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.blobrouter.data;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,7 +123,6 @@ public class EnvelopeEventRepositoryTest {
         assertThat(eventsInDb).isEmpty();
     }
 
-    @NotNull
     private EnvelopeEvent envelopeEvent(UUID envelopeId, NewEnvelopeEvent event, long eventId) {
         return new EnvelopeEvent(eventId, envelopeId, event.type, event.errorCode, event.notes, now());
     }


### PR DESCRIPTION
### Change description ###

https://github.com/testcontainers/testcontainers-java/pull/3159 fixed in new testcontainers release candidate:
https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.0-rc2

I would believe we should upgrade, it's only test dependency and if it fixes the problem, it's better than downgrading docker doing the workarounds on local.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
