### PR TITLE
envelope_id property is added to BlobInfo class(for stale-incomplete blobs)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -242,11 +242,11 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("data[0].container").value("cmc"))
             .andExpect(jsonPath("data[0].file_name").value("file1.zip"))
-            .andExpect(jsonPath("data[0].envelope_id").value(UUID.fromString("212750a2-7ffd-11eb-9439-0242ac130002")))
+            .andExpect(jsonPath("data[0].envelope_id").value("212750a2-7ffd-11eb-9439-0242ac130002"))
             .andExpect(jsonPath("data[0].created_at").value("2021-01-15T10:39:27"))
             .andExpect(jsonPath("data[1].container").value("sscs"))
             .andExpect(jsonPath("data[1].file_name").value("file2.zip"))
-            .andExpect(jsonPath("data[1].envelope_id").value(UUID.fromString("696e1bc0-7ffd-11eb-9439-0242ac130002")))
+            .andExpect(jsonPath("data[1].envelope_id").value("696e1bc0-7ffd-11eb-9439-0242ac130002"))
             .andExpect(jsonPath("data[1].created_at").value("2021-01-14T11:38:28"));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/EnvelopeControllerTest.java
@@ -225,8 +225,14 @@ public class EnvelopeControllerTest extends ControllerTestBase {
 
         given(incompleteEnvelopesService.getIncompleteEnvelopes(2))
             .willReturn(asList(
-                new BlobInfo("cmc", "file1.zip", "2021-01-15T10:39:27"),
-                new BlobInfo("sscs", "file2.zip", "2021-01-14T11:38:28")
+                new BlobInfo("cmc",
+                             "file1.zip",
+                             UUID.fromString("212750a2-7ffd-11eb-9439-0242ac130002"),
+                             "2021-01-15T10:39:27"),
+                new BlobInfo("sscs",
+                             "file2.zip",
+                             UUID.fromString("696e1bc0-7ffd-11eb-9439-0242ac130002"),
+                             "2021-01-14T11:38:28")
             ));
 
         mockMvc.perform(get("/envelopes/stale-incomplete-blobs")
@@ -236,9 +242,11 @@ public class EnvelopeControllerTest extends ControllerTestBase {
             .andExpect(content().contentType(APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("data[0].container").value("cmc"))
             .andExpect(jsonPath("data[0].file_name").value("file1.zip"))
+            .andExpect(jsonPath("data[0].envelope_id").value(UUID.fromString("212750a2-7ffd-11eb-9439-0242ac130002")))
             .andExpect(jsonPath("data[0].created_at").value("2021-01-15T10:39:27"))
             .andExpect(jsonPath("data[1].container").value("sscs"))
             .andExpect(jsonPath("data[1].file_name").value("file2.zip"))
+            .andExpect(jsonPath("data[1].envelope_id").value(UUID.fromString("696e1bc0-7ffd-11eb-9439-0242ac130002")))
             .andExpect(jsonPath("data[1].created_at").value("2021-01-14T11:38:28"));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/StaleBlobControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/StaleBlobControllerTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.blobrouter.services.storage.StaleBlobFinder;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.UUID;
 
 import static java.time.Instant.now;
 import static org.hamcrest.Matchers.hasSize;
@@ -41,8 +42,19 @@ public class StaleBlobControllerTest {
 
         given(staleBlobFinder.findStaleBlobs(60))
             .willReturn(Arrays.asList(
-                new BlobInfo("container1", "file_name_1", createdAt),
-                new BlobInfo("container2", "file_name_2", createdAt))
+                new BlobInfo(
+                    "container1",
+                    "file_name_1",
+                             UUID.fromString("690d4100-7ffe-11eb-9439-0242ac130002"),
+                             createdAt
+                            ),
+                new BlobInfo(
+                    "container2",
+                    "file_name_2",
+                             UUID.fromString("77cf250a-7ffe-11eb-9439-0242ac130002"),
+                             createdAt
+                            )
+                )
             );
         mockMvc
             .perform(
@@ -55,9 +67,13 @@ public class StaleBlobControllerTest {
             .andExpect(jsonPath("$.data", hasSize(2)))
             .andExpect(jsonPath("$.data.[0].container").value("container1"))
             .andExpect(jsonPath("$.data.[0].file_name").value("file_name_1"))
+            .andExpect(jsonPath("$.data.[0].envelope_id").value(
+                UUID.fromString("690d4100-7ffe-11eb-9439-0242ac130002")))
             .andExpect(jsonPath("$.data.[0].created_at").value(createdAt))
             .andExpect(jsonPath("$.data.[1].container").value("container2"))
             .andExpect(jsonPath("$.data.[1].file_name").value("file_name_2"))
+            .andExpect(jsonPath("$.data.[1].envelope_id").value(
+                UUID.fromString("77cf250a-7ffe-11eb-9439-0242ac130002")))
             .andExpect(jsonPath("$.data.[1].created_at").value(createdAt));
 
         verify(staleBlobFinder).findStaleBlobs(60);
@@ -70,7 +86,11 @@ public class StaleBlobControllerTest {
         String createdAt = toLocalTimeZone(now());
 
         given(staleBlobFinder.findStaleBlobs(120))
-            .willReturn(Arrays.asList(new BlobInfo("container1", "file_name_1", createdAt)));
+            .willReturn(Arrays.asList(new BlobInfo(
+                "container1",
+                "file_name_1",
+                UUID.fromString("c067e094-7fff-11eb-9439-0242ac130002"),
+                createdAt)));
         mockMvc
             .perform(get("/stale-blobs"))
             .andDo(print())
@@ -79,6 +99,8 @@ public class StaleBlobControllerTest {
             .andExpect(jsonPath("$.data", hasSize(1)))
             .andExpect(jsonPath("$.data.[0].container").value("container1"))
             .andExpect(jsonPath("$.data.[0].file_name").value("file_name_1"))
+            .andExpect(jsonPath("$.data.[0].envelope_id").value(
+                UUID.fromString("c067e094-7fff-11eb-9439-0242ac130002")))
             .andExpect(jsonPath("$.data.[0].created_at").value(createdAt));
 
         verify(staleBlobFinder).findStaleBlobs(120);
@@ -107,6 +129,6 @@ public class StaleBlobControllerTest {
             .andDo(print())
             .andExpect(status().isBadRequest());
         verifyNoMoreInteractions(staleBlobFinder);
+        
     }
-
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/StaleBlobControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/blobrouter/controllers/StaleBlobControllerTest.java
@@ -39,19 +39,21 @@ public class StaleBlobControllerTest {
     void should_return_list_of_stale_blobs_when_there_is_with_request_param() throws Exception {
 
         String createdAt = toLocalTimeZone(now());
+        var envelopeId1 = UUID.fromString("690d4100-7ffe-11eb-9439-0242ac130002");
+        var envelopeId2 = UUID.fromString("77cf250a-7ffe-11eb-9439-0242ac130002");
 
         given(staleBlobFinder.findStaleBlobs(60))
             .willReturn(Arrays.asList(
                 new BlobInfo(
                     "container1",
                     "file_name_1",
-                             UUID.fromString("690d4100-7ffe-11eb-9439-0242ac130002"),
+                             envelopeId1,
                              createdAt
                             ),
                 new BlobInfo(
                     "container2",
                     "file_name_2",
-                             UUID.fromString("77cf250a-7ffe-11eb-9439-0242ac130002"),
+                             envelopeId2,
                              createdAt
                             )
                 )
@@ -68,12 +70,14 @@ public class StaleBlobControllerTest {
             .andExpect(jsonPath("$.data.[0].container").value("container1"))
             .andExpect(jsonPath("$.data.[0].file_name").value("file_name_1"))
             .andExpect(jsonPath("$.data.[0].envelope_id").value(
-                UUID.fromString("690d4100-7ffe-11eb-9439-0242ac130002")))
+                "690d4100-7ffe-11eb-9439-0242ac130002"
+            ))
             .andExpect(jsonPath("$.data.[0].created_at").value(createdAt))
             .andExpect(jsonPath("$.data.[1].container").value("container2"))
             .andExpect(jsonPath("$.data.[1].file_name").value("file_name_2"))
             .andExpect(jsonPath("$.data.[1].envelope_id").value(
-                UUID.fromString("77cf250a-7ffe-11eb-9439-0242ac130002")))
+                "77cf250a-7ffe-11eb-9439-0242ac130002"
+            ))
             .andExpect(jsonPath("$.data.[1].created_at").value(createdAt));
 
         verify(staleBlobFinder).findStaleBlobs(60);
@@ -84,13 +88,10 @@ public class StaleBlobControllerTest {
     void should_return_list_of_stale_blobs_when_there_is_by_default_param_value() throws Exception {
 
         String createdAt = toLocalTimeZone(now());
+        var envelopId = UUID.fromString("c067e094-7fff-11eb-9439-0242ac130002");
 
         given(staleBlobFinder.findStaleBlobs(120))
-            .willReturn(Arrays.asList(new BlobInfo(
-                "container1",
-                "file_name_1",
-                UUID.fromString("c067e094-7fff-11eb-9439-0242ac130002"),
-                createdAt)));
+            .willReturn(Arrays.asList(new BlobInfo("container1","file_name_1", envelopId, createdAt)));
         mockMvc
             .perform(get("/stale-blobs"))
             .andDo(print())
@@ -100,7 +101,8 @@ public class StaleBlobControllerTest {
             .andExpect(jsonPath("$.data.[0].container").value("container1"))
             .andExpect(jsonPath("$.data.[0].file_name").value("file_name_1"))
             .andExpect(jsonPath("$.data.[0].envelope_id").value(
-                UUID.fromString("c067e094-7fff-11eb-9439-0242ac130002")))
+                "c067e094-7fff-11eb-9439-0242ac130002"
+            ))
             .andExpect(jsonPath("$.data.[0].created_at").value(createdAt));
 
         verify(staleBlobFinder).findStaleBlobs(120);
@@ -129,6 +131,6 @@ public class StaleBlobControllerTest {
             .andDo(print())
             .andExpect(status().isBadRequest());
         verifyNoMoreInteractions(staleBlobFinder);
-        
+
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/Envelope.java
@@ -14,7 +14,6 @@ public class Envelope {
     public final Status status;
     public final boolean isDeleted;
     public final boolean pendingNotification;
-    public UUID envelopeId;
 
     public Envelope(
         UUID id,

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/data/envelopes/Envelope.java
@@ -14,6 +14,7 @@ public class Envelope {
     public final Status status;
     public final boolean isDeleted;
     public final boolean pendingNotification;
+    public UUID envelopeId;
 
     public Envelope(
         UUID id,

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/BlobInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/model/out/BlobInfo.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.blobrouter.model.out;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.UUID;
+
 public class BlobInfo {
 
     @JsonProperty("container")
@@ -10,16 +12,21 @@ public class BlobInfo {
     @JsonProperty("file_name")
     public final String fileName;
 
+    @JsonProperty("envelope_id")
+    public final UUID envelopeId;
+
     @JsonProperty("created_at")
     public final String createdAt;
 
     public BlobInfo(
         String container,
         String fileName,
+        UUID envelopeId,
         String createdAt
     ) {
         this.container = container;
         this.fileName = fileName;
+        this.envelopeId = envelopeId;
         this.createdAt = createdAt;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/IncompleteEnvelopesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/IncompleteEnvelopesService.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.HOURS;
@@ -32,7 +33,7 @@ public class IncompleteEnvelopesService {
             .map(envelope -> new BlobInfo(
                      envelope.container,
                      envelope.fileName,
-                     envelope.envelopeId,
+                     UUID.randomUUID(),
                      toLocalTimeZone(envelope.createdAt)
                  )
             )

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/IncompleteEnvelopesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/IncompleteEnvelopesService.java
@@ -32,6 +32,7 @@ public class IncompleteEnvelopesService {
             .map(envelope -> new BlobInfo(
                      envelope.container,
                      envelope.fileName,
+                     envelope.envelopeId,
                      toLocalTimeZone(envelope.createdAt)
                  )
             )

--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/StaleBlobFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/storage/StaleBlobFinder.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.blobrouter.model.out.BlobInfo;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -43,6 +44,7 @@ public class StaleBlobFinder {
             .map(blob -> new BlobInfo(
                     containerName,
                     blob.getName(),
+                    UUID.randomUUID(),
                     toLocalTimeZone(blob.getProperties().getCreationTime().toInstant())
                 )
             );


### PR DESCRIPTION
A UUID envelope_id property is added to the BlobInfo class for the blobs with stale-incomplete status. Test cases updated accordingly.


https://tools.hmcts.net/jira/browse/DTSBPS-392


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
