### PR TITLE
Stale Blobs Test cases modified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.4.3'
   id 'org.owasp.dependencycheck' version '6.1.1'
-  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.1.1'
   id 'org.flywaydb.flyway' version '7.5.4'
 }
@@ -172,10 +172,6 @@ dependencyManagement {
     dependencySet(group: 'net.minidev', version: '2.3') {
       entry 'json-smart'
     }
-    //avoid   CVE-2020-13943 and CVE-2020-17527
-    dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
-    //avoid   CVE-2020-13943 and CVE-2020-17527
-    dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.2'
     //avoid   CVE-2021-21290
     dependencySet(group: 'io.netty', version: '4.1.59.Final') {
       entry 'netty-buffer'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '6.1.1'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.1.1'
-  id 'org.flywaydb.flyway' version '7.5.4'
+  id 'org.flywaydb.flyway' version '7.6.0'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ ext["rest-assured.version"] = '4.2.1'
 
 dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.19'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '7.5.4'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '7.6.0'
 
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '4.21.0'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '4.21.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,7 +4,7 @@
     <notes><![CDATA[ Hard dependency from azure-storage library ]]></notes>
     <cpe regex="true">cpe:\/a:apache:sling:(0\.1\.0)</cpe>
   </suppress>
-  <suppress until="2021-03-07">
+  <suppress until="2021-06-07">
     <notes><![CDATA[ No fix available ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
     <cve>CVE-2018-1258</cve>
@@ -16,15 +16,5 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpclient@.*$</packageUrl>
     <cve>CVE-2020-13956</cve>
-  </suppress>
-  <suppress until="2021-03-01">
-    <notes><![CDATA[
-   file name: lang-tag-1.4.4.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
-    <cve>CVE-2020-29242</cve>
-    <cve>CVE-2020-29243</cve>
-    <cve>CVE-2020-29244</cve>
-    <cve>CVE-2020-29245</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
For stale blobs, the string form of envelopId is used in test cases by replacing the UUID instance.  Also, instantiation of UUID is made more readable. 

Also, envelopId property is removed from Envelop class.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
