### PR TITLE
add new method to use new query to find envelopes status different th…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeService.java
@@ -50,6 +50,11 @@ public class EnvelopeService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<Envelope> findEnvelopeNotInCreatedStatus(String fileName, String containerName) {
+        return envelopeRepository.findEnvelopeNotInCreatedStatus(fileName, containerName);
+    }
+
+    @Transactional(readOnly = true)
     public Optional<Envelope> findEnvelope(UUID id) {
         return envelopeRepository.find(id);
     }

--- a/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/blobrouter/services/EnvelopeServiceTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -414,4 +415,40 @@ class EnvelopeServiceTest {
             .isNotSameAs(list);
         verifyNoInteractions(eventRepository);
     }
+
+    @Test
+    void should_find_envelope_not_in_created_status() {
+        // given
+        String fileName = "file123.zip";
+        String containerName = "X";
+        var envelope =  mock(Envelope.class);
+        given(envelopeRepository.findEnvelopeNotInCreatedStatus(fileName, containerName))
+            .willReturn(Optional.of(envelope));
+
+        // when
+        Optional<Envelope> envelopeOpt = envelopeService.findEnvelopeNotInCreatedStatus(fileName,containerName);
+
+        // then
+        assertThat(envelopeOpt).hasValue(envelope);
+        verify(envelopeRepository).findEnvelopeNotInCreatedStatus(fileName, containerName);
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
+    void should_not_find_envelope_not_in_created_status() {
+        // given
+        String fileName = "file123.zip";
+        String containerName = "X";
+        given(envelopeRepository.findEnvelopeNotInCreatedStatus(fileName, containerName))
+            .willReturn(Optional.empty());
+
+        // when
+        Optional<Envelope> envelopeOpt = envelopeService.findEnvelopeNotInCreatedStatus(fileName,containerName);
+
+        // then
+        assertThat(envelopeOpt).isEmpty();
+        verify(envelopeRepository).findEnvelopeNotInCreatedStatus(fileName, containerName);
+        verifyNoInteractions(eventRepository);
+    }
+
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSBPS-485

### Change description ###

continue of #1019 
add new method to use new query to find envelopes status different than created


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
