### PR TITLE
Bump apiguardian-api from 1.0.0 to 1.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ def versions = [
   junit           : '5.8.1',
   junitPlatform   : '1.8.1',
   reformLogging   : '5.1.5',
-  apiguardian     : '1.0.0'
+  apiguardian     : '1.1.2'
 ]
 
 ext.libraries = [


### PR DESCRIPTION



### Change description ###

Bump apiguardian-api from 1.0.0 to 1.1.2
instead of #1188 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
