### PR TITLE
Bump Spring dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,15 @@ dependencyManagement {
       entry 'netty-transport-native-kqueue'
       entry 'netty-transport-native-unix-common'
     }
+    //CVE-2022-22970, CVE-2022-22971
+    dependencySet(group: 'org.springframework', version: '5.3.20') {
+      entry 'spring-aop'
+      entry 'spring-beans'
+      entry 'spring-context'
+      entry 'spring-core'
+      entry 'spring-expression'
+      entry 'spring-jcl'
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,11 @@ dependencyManagement {
       entry 'spring-core'
       entry 'spring-expression'
       entry 'spring-jcl'
+      entry 'spring-context-support'
+      entry 'spring-jdbc'
+      entry 'spring-tx'
+      entry 'spring-web'
+      entry 'spring-webmvc'
     }
   }
 }


### PR DESCRIPTION
### Change description ###
Dependency check is failing for CVE-2022-22970 and CVE-2022-22971
Bump spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
