### PR TITLE
FACT-1976 - CVE Updates Sept

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,10 +219,10 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.3'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.4'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-activemq'
   // region: feign clients
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.2'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3'
   implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '13.3'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.3'
   // end region

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
   id 'org.springframework.boot' version '3.2.7'
-  id 'org.owasp.dependencycheck' version '9.0.10'
+  id 'org.owasp.dependencycheck' version '10.0.4'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
   id 'org.flywaydb.flyway' version '10.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -183,9 +183,9 @@ repositories {
 }
 
 def versions = [
-  junit           : '5.11.1',
-  junitPlatform   : '1.11.1',
-  reformLogging   : '6.1.4',
+  junit           : '5.11.0',
+  junitPlatform   : '1.11.0',
+  reformLogging   : '6.1.6',
   apiguardian     : '1.1.2'
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ repositories {
 }
 
 def versions = [
-  junit           : '5.10.1',
-  junitPlatform   : '1.10.1',
+  junit           : '5.11.1',
+  junitPlatform   : '1.11.1',
   reformLogging   : '6.1.4',
   apiguardian     : '1.1.2'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,14 @@
 buildscript {
+  ext {
+    flywayVersion = '10.17.3'
+    postgresqlVersion = '42.7.4'
+  }
   dependencies {
-    classpath("org.postgresql:postgresql:42.7.3")
-    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
+    classpath("org.postgresql:postgresql:$postgresqlVersion") // must be compatible with flyway version
+    classpath("org.flywaydb:flyway-database-postgresql:$flywayVersion") // flyway dependency/plugin versions must always match
   }
 }
+
 plugins {
   id 'application'
   id 'checkstyle'
@@ -14,7 +19,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '10.0.4'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
-  id 'org.flywaydb.flyway' version '10.13.0'
+  id 'org.flywaydb.flyway' version "$flywayVersion"
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -186,7 +191,9 @@ def versions = [
   junit           : '5.11.0',
   junitPlatform   : '1.11.0',
   reformLogging   : '6.1.6',
-  apiguardian     : '1.1.2'
+  apiguardian     : '1.1.2',
+  flyway          : "$flywayVersion",
+  postgresql      : "$postgresqlVersion"
 ]
 
 ext.libraries = [
@@ -202,7 +209,7 @@ ext.libraries = [
 
 dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.13.0'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
 
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.14.0'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '5.14.0'
@@ -279,7 +286,7 @@ dependencies {
     exclude group: 'junit', module: 'junit'
   }
 
-  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: versions.flyway
 }
 
 mainClassName = 'uk.gov.hmcts.reform.blobrouter.Application'

--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ dependencies {
 
   implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.11.0'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
-  implementation group: 'com.google.guava', name: 'guava', version: '33.2.1-jre'
+  implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ dependencies {
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '5.14.0'
 
   implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.25.0'
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.2'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.3'
 
   implementation group: 'org.apache.qpid', name: 'qpid-jms-client', version: '1.11.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
   id 'org.springframework.boot' version '3.2.7'
-  id 'org.owasp.dependencycheck' version '10.0.4'
+  id 'org.owasp.dependencycheck' version '9.2.0'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
   id 'org.flywaydb.flyway' version "$flywayVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ dependencies {
   implementation group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
   implementation group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0' // until logging-appinsights supports SB 3.x
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
   implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.8'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ dependencies {
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation libraries.junit5
-  functionalTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+  functionalTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
   functionalTestImplementation group: 'com.jayway.awaitility', name: 'awaitility', version: '1.7.0'
   functionalTestImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
   functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured', {

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ ext.libraries = [
 ]
 
 dependencies {
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
+  implementation group: 'org.postgresql', name: 'postgresql', version: versions.postgresql
   implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
 
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
-  id 'org.springframework.boot' version '3.2.7'
+  id 'org.springframework.boot' version '3.3.3'
   id 'org.owasp.dependencycheck' version '9.2.0'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
-    version: 1.0.6
+    version: 1.0.7
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: servicebus.enabled
   - name: blobstorage

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 1.0.28
+version: 1.0.27
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 5.2.1
+    version: 5.2.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 1.0.6

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -11,12 +11,12 @@ dependencies:
     version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
-    version: 1.0.7
+    version: 1.0.6
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: servicebus.enabled
   - name: blobstorage
     alias: reformblobstorage
-    version: 2.0.2
+    version: 2.0.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: reformblobstorage.enabled
   - name: blobstorage

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 1.0.26
+version: 1.0.27
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 5.2.0
+    version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 1.0.6

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -16,16 +16,16 @@ dependencies:
     condition: servicebus.enabled
   - name: blobstorage
     alias: reformblobstorage
-    version: 2.0.1
+    version: 2.0.2
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: reformblobstorage.enabled
   - name: blobstorage
     alias: crimeblobstorage
-    version: 2.0.1
+    version: 2.0.2
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: crimeblobstorage.enabled
   - name: blobstorage
     alias: pcqblobstorage
-    version: 2.0.1
+    version: 2.0.2
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: pcqblobstorage.enabled

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 1.0.27
+version: 1.0.28
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net
@@ -11,12 +11,12 @@ dependencies:
     version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
-    version: 1.0.6
+    version: 1.0.7
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: servicebus.enabled
   - name: blobstorage
     alias: reformblobstorage
-    version: 2.0.1
+    version: 2.0.2
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: reformblobstorage.enabled
   - name: blobstorage

--- a/charts/reform-scan-blob-router/Chart.yaml
+++ b/charts/reform-scan-blob-router/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 description: A Helm chart for Blob Router Service
 name: reform-scan-blob-router
 home: https://github.com/hmcts/blob-router-service
-version: 1.0.27
+version: 1.0.28
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 5.2.0
+    version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 1.0.6

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2024-04-29">
-    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
-    <cve>CVE-2023-35116</cve>
-  </suppress>
   <suppress until="2025-02-01">
     <notes>Azure cli. Wait for fix.</notes>
     <cve>CVE-2023-36052</cve>
-  </suppress>
-  <suppress>
-    <notes>Jackson-databind. Wait for newer springdoc.</notes>
-    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2025-02-01">
-    <notes>Azure cli. Wait for fix.</notes>
+    <notes>Azure cli. Wait for version of azure-storage-blob higher than 12.27.1.</notes>
     <cve>CVE-2023-36052</cve>
   </suppress>
 </suppressions>

--- a/infrastructure/cft-api-mgmt.tf
+++ b/infrastructure/cft-api-mgmt.tf
@@ -18,10 +18,6 @@ module "cft_api_mgmt_product" {
   product_access_control_groups = ["developers"]
   approval_required             = "false"
   subscription_required         = "true"
-
-  providers = {
-    azurerm = azurerm.aks-cftapps
-  }
 }
 
 module "cft_api_mgmt" {
@@ -37,10 +33,6 @@ module "cft_api_mgmt" {
   service_url    = "http://${var.product}-${var.component}-${var.env}.service.core-compute-${var.env}.internal"
   swagger_url    = "https://hmcts.github.io/cnp-api-docs/specs/blob-router-service.json"
   content_format = "openapi-link"
-
-  providers = {
-    azurerm = azurerm.aks-cftapps
-  }
 }
 
 module "cft_api_mgmt_policy" {
@@ -49,9 +41,4 @@ module "cft_api_mgmt_policy" {
   api_mgmt_rg            = local.api_mgmt_rg
   api_name               = module.cft_api_mgmt.name
   api_policy_xml_content = replace(file("cft-api-policy.xml"), "ALLOWED_CERTIFICATE_THUMBPRINTS", join(",", formatlist("\"%s\"", local.allowed_certificate_thumbprints)))
-
-
-  providers = {
-    azurerm = azurerm.aks-cftapps
-  }
 }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.48.0"
+      version = "2.53.1"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1976

### Change description ###

- Updates dependencies. 
- Puts the Flyway and Postgresql version into builscript block property so that the version can be updated in one place
- Removes suppressions except the one for Azure CLI that cannot be removed until azure-storage-blob can be updated (see suppression note)
- The providers blocks have been removed in order to stop a Terraform warning (see screenshot). The provider blocks may not be needed as the provider is already given in [main.tf](https://github.com/hmcts/blob-router-service/blob/9ebe7fe27e4a129440c29c2c278737f21f86b8cb/infrastructure/main.tf#L13).

![Screenshot 2024-09-16 at 10 47 01](https://github.com/user-attachments/assets/a1ad3099-e078-40e8-ad00-2711785b021a)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
